### PR TITLE
Shrink openssl by removing unwinding info

### DIFF
--- a/pkg/openssl3/build.sh
+++ b/pkg/openssl3/build.sh
@@ -2,6 +2,6 @@
 set -e
 set -x
 
-"$SRCDIR/Configure" "linux-$ARCH" no-shared --cross-compile-prefix="$ARCH-linux-musl-" --prefix="$SYSROOT"
+"$SRCDIR/Configure" "linux-$ARCH" no-shared --cross-compile-prefix="$ARCH-linux-musl-" --prefix="$SYSROOT" -fno-asynchronous-unwind-tables
 make -j`nproc`
 make -j`nproc` install_sw


### PR DESCRIPTION
Previous results show this saving between 300-400kb.

> This option determines whether unwind information is precise at an instruction boundary or at a call boundary. The compiler generates an unwind table in DWARF2 or DWARF3 format, depending on which format is supported on your system.
> If -fno-asynchronous-unwind-tables is specified, the unwind table is precise at call boundaries only. In this case, the compiler will avoid creating unwind tables for routines such as the following:
> A C++ routine that does not declare objects with destructors and does not contain calls to routines that might throw an exception.
> A C/C++ or Fortran routine compiled without -fexceptions, and on Intel® 64 architecture, without -traceback.
> A C/C++ or Fortran routine compiled with -fexceptions that does not contain calls to routines that might throw an exception.

I don't think we care about unwinding out of openssl. The openssl crate only declares functions as extern c today, not extern c-unwind. The usecases I see for having this data tends to be more for things like JITs, where you actually need instruction-level precision for functionality. openssl doesn't do anything like that afaik.

Do we want to go even further with something like -fno-unwind-tables? or -fno-exceptions?