### PR TITLE
CI: Update GitHub release token name

### DIFF
--- a/azure-pipeline.yml
+++ b/azure-pipeline.yml
@@ -66,5 +66,5 @@ jobs:
         displayName: Create GitHub release
         condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
         env:
-          token: $(GITHUB_RELEASE_TOKEN)
+          token: $(CREATE_RELEASE_TOKEN)
           version: "0.1.0-$(build.BuildNumber)"


### PR DESCRIPTION
Turns out secrets cannot begin with the GITHUB_ prefix. I noticed that our old secret got removed, so I've regenerated a new one with a name that doesn't violate the naming requirements.

https://github.com/github/docs/issues/34107