### PR TITLE
Add cgmanifest.json for Component Governance

### DIFF
--- a/azure-pipeline.yml
+++ b/azure-pipeline.yml
@@ -37,6 +37,20 @@ jobs:
           artifact: ${{ platform.architecture }}
           publishLocation: pipeline
 
+  - job: cgmanifest
+    displayName: Verify cgmanifest.json is in sync with Dockerfile
+    pool:
+      name: HvLite-CI-Linux-Pool-WestUS2
+      vmImage: MMSUbuntu20.04-1TB-2
+      demands:
+          - ImageOverride -equals MMSUbuntu20.04-1TB-2
+    steps:
+      - checkout: self
+        fetchDepth: 1
+
+      - bash: python3 pkg/Tools/gen-cgmanifest.py --check
+        displayName: gen-cgmanifest.py --check
+
   - job: package
     pool: HvLite-CI-Linux-Pool-WestUS2
     dependsOn: [aarch64, x86_64]

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -165,6 +165,17 @@
       },
       "developmentDependency": false,
       "licensesConcluded": ["Apache-2.0"]
+    },
+    {
+      "component": {
+        "type": "git",
+        "git": {
+          "repositoryUrl": "https://github.com/microsoft/SymCrypt",
+          "commitHash": "748c20f1fc486beca1a2679ed06492712cfdc950"
+        }
+      },
+      "developmentDependency": false,
+      "licensesConcluded": ["MIT"]
     }
   ]
 }

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -1,0 +1,170 @@
+{
+  "$schema": "https://json.schemastore.org/component-detection-manifest.json",
+  "version": 1,
+  "registrations": [
+    {
+      "component": {
+        "type": "git",
+        "git": {
+          "repositoryUrl": "https://github.com/richfelker/musl-cross-make",
+          "commitHash": "6f3701d08137496d5aac479e3a3977b5ae993c1f"
+        }
+      },
+      "developmentDependency": true,
+      "licensesConcluded": ["MIT"]
+    },
+    {
+      "component": {
+        "type": "other",
+        "other": {
+          "name": "binutils",
+          "version": "2.33.1",
+          "downloadUrl": "https://ftpmirror.gnu.org/gnu/binutils/binutils-2.33.1.tar.xz",
+          "hash": "ab66fc2d1c3ec0359b8e08843c9f33b63e8707efdff5e4cc5c200eae24722cbf",
+          "packageUrl": "pkg:generic/binutils@2.33.1",
+          "sourceUrl": "https://sourceware.org/git/binutils-gdb.git"
+        }
+      },
+      "developmentDependency": true,
+      "licensesConcluded": ["GPL-3.0-or-later"]
+    },
+    {
+      "component": {
+        "type": "other",
+        "other": {
+          "name": "gnu-config",
+          "version": "3d5db9ebe860",
+          "downloadUrl": "https://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.sub;hb=3d5db9ebe860",
+          "hash": "75d5d255a2a273b6e651f82eecfabf6cbcd8eaeae70e86b417384c8f4a58d8d3",
+          "packageUrl": "pkg:generic/gnu-config@3d5db9ebe860",
+          "sourceUrl": "https://git.savannah.gnu.org/cgit/config.git"
+        }
+      },
+      "developmentDependency": true,
+      "licensesConcluded": ["GPL-3.0-or-later WITH Autoconf-exception-3.0"]
+    },
+    {
+      "component": {
+        "type": "other",
+        "other": {
+          "name": "gcc",
+          "version": "11.5.0",
+          "downloadUrl": "https://ftpmirror.gnu.org/gnu/gcc/gcc-11.5.0/gcc-11.5.0.tar.xz",
+          "hash": "a6e21868ead545cf87f0c01f84276e4b5281d672098591c1c896241f09363478",
+          "packageUrl": "pkg:generic/gcc@11.5.0",
+          "sourceUrl": "https://gcc.gnu.org/git/gcc.git"
+        }
+      },
+      "developmentDependency": false,
+      "licensesConcluded": ["GPL-3.0-or-later WITH GCC-exception-3.1"]
+    },
+    {
+      "component": {
+        "type": "other",
+        "other": {
+          "name": "gmp",
+          "version": "6.1.2",
+          "downloadUrl": "https://ftpmirror.gnu.org/gnu/gmp/gmp-6.1.2.tar.bz2",
+          "hash": "5275bb04f4863a13516b2f39392ac5e272f5e1bb8057b18aec1c9b79d73d8fb2",
+          "packageUrl": "pkg:generic/gmp@6.1.2",
+          "sourceUrl": "https://gmplib.org/repo/gmp/"
+        }
+      },
+      "developmentDependency": true,
+      "licensesConcluded": ["LGPL-3.0-or-later OR GPL-2.0-or-later"]
+    },
+    {
+      "component": {
+        "type": "other",
+        "other": {
+          "name": "linux-headers-sabotage",
+          "version": "4.19.88-2",
+          "downloadUrl": "https://ftp.barfooze.de/pub/sabotage/tarballs/linux-headers-4.19.88-2.tar.xz",
+          "hash": "dc7abf734487553644258a3822cfd429d74656749e309f2b25f09f4282e05588",
+          "packageUrl": "pkg:generic/linux-headers-sabotage@4.19.88-2",
+          "sourceUrl": "https://ftp.barfooze.de/pub/sabotage/tarballs/"
+        }
+      },
+      "developmentDependency": true,
+      "licensesConcluded": ["GPL-2.0-only"]
+    },
+    {
+      "component": {
+        "type": "other",
+        "other": {
+          "name": "mpc",
+          "version": "1.1.0",
+          "downloadUrl": "https://ftpmirror.gnu.org/gnu/mpc/mpc-1.1.0.tar.gz",
+          "hash": "6985c538143c1208dcb1ac42cedad6ff52e267b47e5f970183a3e75125b43c2e",
+          "packageUrl": "pkg:generic/mpc@1.1.0",
+          "sourceUrl": "https://gitlab.inria.fr/mpc/mpc"
+        }
+      },
+      "developmentDependency": true,
+      "licensesConcluded": ["LGPL-3.0-or-later"]
+    },
+    {
+      "component": {
+        "type": "other",
+        "other": {
+          "name": "mpfr",
+          "version": "4.0.2",
+          "downloadUrl": "https://ftpmirror.gnu.org/gnu/mpfr/mpfr-4.0.2.tar.bz2",
+          "hash": "c05e3f02d09e0e9019384cdd58e0f19c64e6db1fd6f5ecf77b4b1c61ca253acc",
+          "packageUrl": "pkg:generic/mpfr@4.0.2",
+          "sourceUrl": "https://gitlab.inria.fr/mpfr/mpfr"
+        }
+      },
+      "developmentDependency": true,
+      "licensesConcluded": ["LGPL-3.0-or-later"]
+    },
+    {
+      "component": {
+        "type": "other",
+        "other": {
+          "name": "musl",
+          "version": "1.2.5",
+          "downloadUrl": "https://musl.libc.org/releases/musl-1.2.5.tar.gz",
+          "hash": "a9a118bbe84d8764da0ea0d28b3ab3fae8477fc7e4085d90102b8596fc7c75e4",
+          "packageUrl": "pkg:generic/musl@1.2.5",
+          "sourceUrl": "https://git.musl-libc.org/cgit/musl"
+        }
+      },
+      "developmentDependency": false,
+      "licensesConcluded": ["MIT"]
+    },
+    {
+      "component": {
+        "type": "git",
+        "git": {
+          "repositoryUrl": "https://github.com/gregkh/linux",
+          "commitHash": "8fd7f44624538675abadc73f5a44e95016964d22"
+        }
+      },
+      "developmentDependency": false,
+      "licensesConcluded": ["GPL-2.0-only WITH Linux-syscall-note"]
+    },
+    {
+      "component": {
+        "type": "git",
+        "git": {
+          "repositoryUrl": "https://github.com/llvm/llvm-project",
+          "commitHash": "6009708b4367171ccdbf4b5905cb6a803753fe18"
+        }
+      },
+      "developmentDependency": false,
+      "licensesConcluded": ["Apache-2.0 WITH LLVM-exception"]
+    },
+    {
+      "component": {
+        "type": "git",
+        "git": {
+          "repositoryUrl": "https://github.com/openssl/openssl",
+          "commitHash": "27315a978e280a20c7f3ea0bfe05f6c186137625"
+        }
+      },
+      "developmentDependency": false,
+      "licensesConcluded": ["Apache-2.0"]
+    }
+  ]
+}

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -4,44 +4,25 @@
   "registrations": [
     {
       "component": {
-        "type": "git",
-        "git": {
-          "repositoryUrl": "https://github.com/richfelker/musl-cross-make",
-          "commitHash": "6f3701d08137496d5aac479e3a3977b5ae993c1f"
-        }
-      },
-      "developmentDependency": true,
-      "licensesConcluded": ["MIT"]
-    },
-    {
-      "component": {
         "type": "other",
         "other": {
           "name": "binutils",
           "version": "2.33.1",
           "downloadUrl": "https://ftpmirror.gnu.org/gnu/binutils/binutils-2.33.1.tar.xz",
-          "hash": "ab66fc2d1c3ec0359b8e08843c9f33b63e8707efdff5e4cc5c200eae24722cbf",
-          "packageUrl": "pkg:generic/binutils@2.33.1",
-          "sourceUrl": "https://sourceware.org/git/binutils-gdb.git"
+          "hash": "ab66fc2d1c3ec0359b8e08843c9f33b63e8707efdff5e4cc5c200eae24722cbf"
         }
-      },
-      "developmentDependency": true,
-      "licensesConcluded": ["GPL-3.0-or-later"]
+      }
     },
     {
       "component": {
         "type": "other",
         "other": {
-          "name": "gnu-config",
-          "version": "3d5db9ebe860",
+          "name": "unknown",
+          "version": "0",
           "downloadUrl": "https://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.sub;hb=3d5db9ebe860",
-          "hash": "75d5d255a2a273b6e651f82eecfabf6cbcd8eaeae70e86b417384c8f4a58d8d3",
-          "packageUrl": "pkg:generic/gnu-config@3d5db9ebe860",
-          "sourceUrl": "https://git.savannah.gnu.org/cgit/config.git"
+          "hash": "75d5d255a2a273b6e651f82eecfabf6cbcd8eaeae70e86b417384c8f4a58d8d3"
         }
-      },
-      "developmentDependency": true,
-      "licensesConcluded": ["GPL-3.0-or-later WITH Autoconf-exception-3.0"]
+      }
     },
     {
       "component": {
@@ -50,13 +31,9 @@
           "name": "gcc",
           "version": "11.5.0",
           "downloadUrl": "https://ftpmirror.gnu.org/gnu/gcc/gcc-11.5.0/gcc-11.5.0.tar.xz",
-          "hash": "a6e21868ead545cf87f0c01f84276e4b5281d672098591c1c896241f09363478",
-          "packageUrl": "pkg:generic/gcc@11.5.0",
-          "sourceUrl": "https://gcc.gnu.org/git/gcc.git"
+          "hash": "a6e21868ead545cf87f0c01f84276e4b5281d672098591c1c896241f09363478"
         }
-      },
-      "developmentDependency": false,
-      "licensesConcluded": ["GPL-3.0-or-later WITH GCC-exception-3.1"]
+      }
     },
     {
       "component": {
@@ -65,28 +42,20 @@
           "name": "gmp",
           "version": "6.1.2",
           "downloadUrl": "https://ftpmirror.gnu.org/gnu/gmp/gmp-6.1.2.tar.bz2",
-          "hash": "5275bb04f4863a13516b2f39392ac5e272f5e1bb8057b18aec1c9b79d73d8fb2",
-          "packageUrl": "pkg:generic/gmp@6.1.2",
-          "sourceUrl": "https://gmplib.org/repo/gmp/"
+          "hash": "5275bb04f4863a13516b2f39392ac5e272f5e1bb8057b18aec1c9b79d73d8fb2"
         }
-      },
-      "developmentDependency": true,
-      "licensesConcluded": ["LGPL-3.0-or-later OR GPL-2.0-or-later"]
+      }
     },
     {
       "component": {
         "type": "other",
         "other": {
-          "name": "linux-headers-sabotage",
+          "name": "linux-headers",
           "version": "4.19.88-2",
           "downloadUrl": "https://ftp.barfooze.de/pub/sabotage/tarballs/linux-headers-4.19.88-2.tar.xz",
-          "hash": "dc7abf734487553644258a3822cfd429d74656749e309f2b25f09f4282e05588",
-          "packageUrl": "pkg:generic/linux-headers-sabotage@4.19.88-2",
-          "sourceUrl": "https://ftp.barfooze.de/pub/sabotage/tarballs/"
+          "hash": "dc7abf734487553644258a3822cfd429d74656749e309f2b25f09f4282e05588"
         }
-      },
-      "developmentDependency": true,
-      "licensesConcluded": ["GPL-2.0-only"]
+      }
     },
     {
       "component": {
@@ -95,13 +64,9 @@
           "name": "mpc",
           "version": "1.1.0",
           "downloadUrl": "https://ftpmirror.gnu.org/gnu/mpc/mpc-1.1.0.tar.gz",
-          "hash": "6985c538143c1208dcb1ac42cedad6ff52e267b47e5f970183a3e75125b43c2e",
-          "packageUrl": "pkg:generic/mpc@1.1.0",
-          "sourceUrl": "https://gitlab.inria.fr/mpc/mpc"
+          "hash": "6985c538143c1208dcb1ac42cedad6ff52e267b47e5f970183a3e75125b43c2e"
         }
-      },
-      "developmentDependency": true,
-      "licensesConcluded": ["LGPL-3.0-or-later"]
+      }
     },
     {
       "component": {
@@ -110,13 +75,9 @@
           "name": "mpfr",
           "version": "4.0.2",
           "downloadUrl": "https://ftpmirror.gnu.org/gnu/mpfr/mpfr-4.0.2.tar.bz2",
-          "hash": "c05e3f02d09e0e9019384cdd58e0f19c64e6db1fd6f5ecf77b4b1c61ca253acc",
-          "packageUrl": "pkg:generic/mpfr@4.0.2",
-          "sourceUrl": "https://gitlab.inria.fr/mpfr/mpfr"
+          "hash": "c05e3f02d09e0e9019384cdd58e0f19c64e6db1fd6f5ecf77b4b1c61ca253acc"
         }
-      },
-      "developmentDependency": true,
-      "licensesConcluded": ["LGPL-3.0-or-later"]
+      }
     },
     {
       "component": {
@@ -125,13 +86,18 @@
           "name": "musl",
           "version": "1.2.5",
           "downloadUrl": "https://musl.libc.org/releases/musl-1.2.5.tar.gz",
-          "hash": "a9a118bbe84d8764da0ea0d28b3ab3fae8477fc7e4085d90102b8596fc7c75e4",
-          "packageUrl": "pkg:generic/musl@1.2.5",
-          "sourceUrl": "https://git.musl-libc.org/cgit/musl"
+          "hash": "a9a118bbe84d8764da0ea0d28b3ab3fae8477fc7e4085d90102b8596fc7c75e4"
         }
-      },
-      "developmentDependency": false,
-      "licensesConcluded": ["MIT"]
+      }
+    },
+    {
+      "component": {
+        "type": "git",
+        "git": {
+          "repositoryUrl": "https://github.com/richfelker/musl-cross-make",
+          "commitHash": "6f3701d08137496d5aac479e3a3977b5ae993c1f"
+        }
+      }
     },
     {
       "component": {
@@ -140,9 +106,7 @@
           "repositoryUrl": "https://github.com/gregkh/linux",
           "commitHash": "8fd7f44624538675abadc73f5a44e95016964d22"
         }
-      },
-      "developmentDependency": false,
-      "licensesConcluded": ["GPL-2.0-only WITH Linux-syscall-note"]
+      }
     },
     {
       "component": {
@@ -151,9 +115,7 @@
           "repositoryUrl": "https://github.com/llvm/llvm-project",
           "commitHash": "6009708b4367171ccdbf4b5905cb6a803753fe18"
         }
-      },
-      "developmentDependency": false,
-      "licensesConcluded": ["Apache-2.0 WITH LLVM-exception"]
+      }
     },
     {
       "component": {
@@ -162,20 +124,16 @@
           "repositoryUrl": "https://github.com/openssl/openssl",
           "commitHash": "27315a978e280a20c7f3ea0bfe05f6c186137625"
         }
-      },
-      "developmentDependency": false,
-      "licensesConcluded": ["Apache-2.0"]
+      }
     },
     {
       "component": {
         "type": "git",
         "git": {
-          "repositoryUrl": "https://github.com/microsoft/SymCrypt",
+          "repositoryUrl": "https://github.com/microsoft/symcrypt",
           "commitHash": "748c20f1fc486beca1a2679ed06492712cfdc950"
         }
-      },
-      "developmentDependency": false,
-      "licensesConcluded": ["MIT"]
+      }
     }
   ]
 }

--- a/pkg/Tools/gen-cgmanifest.py
+++ b/pkg/Tools/gen-cgmanifest.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""Regenerate cgmanifest.json from Dockerfile ADD lines.
+
+Usage:
+    gen-cgmanifest.py            # write cgmanifest.json
+    gen-cgmanifest.py --check    # exit 1 if cgmanifest.json is out of sync (CI)
+"""
+import json
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent.parent
+MANIFEST = ROOT / "cgmanifest.json"
+
+text = re.sub(r"\\\r?\n\s*", " ", (ROOT / "Dockerfile").read_text())
+
+regs = []
+for m in re.finditer(r"^\s*ADD\s+(.+)$", text, re.M):
+    rest = m.group(1)
+    if g := re.search(r"(https?://\S+?)\.git#([0-9a-f]{40})\b", rest):
+        regs.append({"component": {"type": "git", "git": {
+            "repositoryUrl": g.group(1), "commitHash": g.group(2)}}})
+    elif (c := re.search(r"--checksum=sha256:([0-9a-f]{64})", rest)) and \
+         (u := re.search(r"https?://\S+", rest)):
+        fname = u.group(0).rsplit("/", 1)[-1].split("?")[0]
+        nv = re.match(r"(.+?)-(\d[\w.-]*)\.tar\.\w+$", fname)
+        name, version = (nv.group(1), nv.group(2)) if nv else (fname or "unknown", "0")
+        regs.append({"component": {"type": "other", "other": {
+            "name": name, "version": version,
+            "downloadUrl": u.group(0), "hash": c.group(1)}}})
+    elif re.search(r"https?://\S+", rest):
+        sys.exit(f"gen-cgmanifest: unrecognized remote ADD line (needs "
+                 f"--checksum=sha256:<64-hex> or <git-url>.git#<40-hex>):\n  ADD {rest}")
+
+out = json.dumps({
+    "$schema": "https://json.schemastore.org/component-detection-manifest.json",
+    "version": 1, "registrations": regs}, indent=2) + "\n"
+
+if "--check" in sys.argv[1:]:
+    if not MANIFEST.exists() or MANIFEST.read_text() != out:
+        sys.exit(f"{MANIFEST.name} is out of sync with Dockerfile; "
+                 f"rerun pkg/Tools/gen-cgmanifest.py and commit the result.")
+    print(f"{MANIFEST.name} is up to date ({len(regs)} components).")
+else:
+    MANIFEST.write_text(out)
+    print(f"Wrote {MANIFEST.name} ({len(regs)} components).")


### PR DESCRIPTION
## What

Adds a top-level `cgmanifest.json` declaring the third-party components fetched at Docker build time (musl-cross-make toolchain pieces, the Linux kernel, LLVM, OpenSSL, etc.).

## Why

[Component Governance (CG)](https://aka.ms/opensource/cg) cannot see inside Dockerfiles. Detectors like `ComponentDetection.Detectors.CgManifest` and `ComponentDetection.Detectors.Git` scan the agent filesystem; they don't understand `ADD --checksum=... <url>` or `ADD --link <git>#<sha>` as dependency declarations.

Concretely: across all repos that build on top of `openvmm-deps`, the CG dashboards currently attribute **zero** components to the upstream tarballs and git pins this repo's Dockerfile fetches. Only the Python/npm GitHub Actions tooling shows up (via Dependabot/GitHubAdvisories on this repo).

A `cgmanifest.json` is the standard way to fill this gap - the CgManifest detector reads it directly and registers the listed components in CG inventory + SBOMs + CVE matching.

## What's in it

12 registrations, mirroring `hvlite-deps/Dockerfile`:

| Component | Type | Pin | Ships at runtime? |
|---|---|---|---|
| musl-cross-make | git | `6f3701d0` | no (build driver) |
| binutils | other | 2.33.1 | no |
| gnu-config | other | `3d5db9ebe860` | no |
| gcc | other | 11.5.0 | **yes** (libgcc.a) |
| gmp | other | 6.1.2 | no |
| linux-headers-sabotage | other | 4.19.88-2 | no (musl bootstrap UAPI) |
| mpc | other | 1.1.0 | no |
| mpfr | other | 4.0.2 | no |
| musl | other | 1.2.5 | **yes** (libc) |
| linux | git | `8fd7f446` (v6.1.74) | **yes** (kernel headers) |
| llvm-project | git | `6009708b` (release/17.x) | **yes** (libunwind) |
| openssl | git | `27315a97` (3.2.0-dev) | **yes** |

All `developmentDependency` flags are set accordingly. SHA-256 checksums and commit SHAs are copied verbatim from the Dockerfile.

## Notes / gaps

- The base image's Azure Linux 3 packages installed via `tdnf` aren't enumerated here. Those float and are best captured downstream via [`sbom-tool`](https://github.com/microsoft/sbom-tool) run against the built sysroot. Open to adding that to the pipeline if desired.
- `other`-type components don't match CVE feeds as well as ecosystem-specific types; `packageUrl` (purl) and `sourceUrl` are included on each as the best mitigation. Git-type components match GitHub Advisory Database normally.
- Manifest validates clean against [the schema](https://json.schemastore.org/component-detection-manifest.json) (draft-04, `ajv-draft-04`).

## Future work (separate PR)

To prevent this file from drifting when the Dockerfile is bumped, a small generator script that derives `cgmanifest.json` from the Dockerfile + a `git diff --exit-code` CI gate would catch missed updates automatically. Happy to send that as a follow-up.
