### PR TITLE
Ship RPM database in sysroots and emit SPDX SBOMs

### DIFF
--- a/azure-pipeline.yml
+++ b/azure-pipeline.yml
@@ -30,6 +30,15 @@ jobs:
       - bash: docker build --platform "${{ platform.architecture }}" --output type=local,dest=out .
         displayName: Build ${{ platform.architecture }} outputs
 
+      - bash: |
+          set -euo pipefail
+          curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh \
+              | sh -s -- -b /usr/local/bin v1.14.1
+          syft version
+          chmod +x pkg/Tools/gen-sboms.sh
+          pkg/Tools/gen-sboms.sh out out/sboms
+        displayName: Generate SPDX SBOMs (${{ platform.architecture }})
+
       - task: PublishPipelineArtifact@1
         displayName: 'Publish output'
         inputs:

--- a/pkg/Tools/build.sh
+++ b/pkg/Tools/build.sh
@@ -92,8 +92,11 @@ for pkg in "${pkgs[@]}"; do
     fi
 done
 
-# Remove package indexes and other cruft.
-rm -rf "$SYSROOT/var/cache/tdnf" "$SYSROOT/var/lib/rpm" "$SYSROOT/usr/share/man" "$SYSROOT/usr/share/doc"
+# Remove tdnf cache, man pages, and docs to shrink the rootfs.
+# Intentionally keep /var/lib/rpm so SBOM tools (syft, sbom-tool,
+# Component Detection's Linux detector) can enumerate installed
+# packages from the shipped artifact.
+rm -rf "$SYSROOT/var/cache/tdnf" "$SYSROOT/usr/share/man" "$SYSROOT/usr/share/doc"
 
 if [ -n "$BUILD_EROFS" ]; then
     mkfs.erofs -zlz4hc -Efragments,dedupe "${OUTPUTDIR}/sysroot.erofs" "$SYSROOT"

--- a/pkg/Tools/gen-sboms.sh
+++ b/pkg/Tools/gen-sboms.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+#
+# Generate SPDX SBOMs for each shipped sysroot artifact using syft.
+#
+# Each artifact contains /var/lib/rpm (the RPM database), which syft reads
+# natively to enumerate installed packages. SPDX output is the standard
+# SBOM format consumed by sbom-tool, Component Detection, and Defender.
+#
+# Inputs:
+#   $1  Directory containing the build outputs (e.g. dbgrd.cpio.gz, ...)
+#   $2  Directory to write the *.spdx.json files into
+#
+# Requires: syft on PATH (single Go binary).
+
+set -euo pipefail
+
+INDIR="${1:?usage: gen-sboms.sh <inputs-dir> <outputs-dir>}"
+OUTDIR="${2:?usage: gen-sboms.sh <inputs-dir> <outputs-dir>}"
+
+mkdir -p "$OUTDIR"
+
+SCRATCH="$(mktemp -d)"
+trap 'rm -rf "$SCRATCH"' EXIT
+
+scan() {
+    local artifact="$1"
+    local name="$2"
+    local extracted="$SCRATCH/$name"
+
+    mkdir -p "$extracted"
+    case "$artifact" in
+        *.cpio.gz)
+            bsdtar -xf "$artifact" -C "$extracted"
+            ;;
+        *.tar.gz|*.tgz)
+            tar -xzf "$artifact" -C "$extracted"
+            ;;
+        initrd)
+            # initrd is a gzipped cpio archive (see Dockerfile build-initrd stage).
+            bsdtar -xf "$artifact" -C "$extracted"
+            ;;
+        *)
+            echo "Skipping unsupported artifact format: $artifact" >&2
+            return
+            ;;
+    esac
+
+    if [[ ! -d "$extracted/var/lib/rpm" ]]; then
+        echo "Skipping $name: no RPM database found inside artifact" >&2
+        return
+    fi
+
+    echo "Scanning $name..."
+    syft scan "dir:$extracted" \
+        --source-name "$name" \
+        -o "spdx-json=$OUTDIR/$name.spdx.json"
+}
+
+shopt -s nullglob
+for artifact in "$INDIR"/*.cpio.gz "$INDIR"/*.tar.gz "$INDIR"/initrd; do
+    [ -e "$artifact" ] || continue
+    name="$(basename "$artifact")"
+    name="${name%.cpio.gz}"
+    name="${name%.tar.gz}"
+    scan "$artifact" "$name"
+done
+
+echo "Generated SBOMs:"
+ls -la "$OUTDIR"

--- a/pkg/Tools/gen-sboms.sh
+++ b/pkg/Tools/gen-sboms.sh
@@ -30,14 +30,14 @@ scan() {
     mkdir -p "$extracted"
     case "$artifact" in
         *.cpio.gz)
-            bsdtar -xf "$artifact" -C "$extracted"
+            gunzip -c "$artifact" | (cd "$extracted" && cpio -idm 2>/dev/null)
             ;;
         *.tar.gz|*.tgz)
             tar -xzf "$artifact" -C "$extracted"
             ;;
         initrd)
             # initrd is a gzipped cpio archive (see Dockerfile build-initrd stage).
-            bsdtar -xf "$artifact" -C "$extracted"
+            gunzip -c "$artifact" | (cd "$extracted" && cpio -idm 2>/dev/null)
             ;;
         *)
             echo "Skipping unsupported artifact format: $artifact" >&2


### PR DESCRIPTION
Stop deleting `/var/lib/rpm` from the built sysroots, and add a build step that runs syft against each output artifact to emit standards-compliant SPDX 2.3 SBOMs.

## Why

Component Governance / sbom-tool / Defender all expect SBOMs as their input. Without the RPM database in the shipped artifacts, there's no way to enumerate what's actually installed -- the package list (busybox, gdb, strace, ethtool, kernel-tools, etc.) is invisible to every dependency-tracking tool downstream.

The current `cgmanifest.json` only covers our from-source dependencies (musl-cross-make, llvm, openssl, symcrypt, ms-tpm-20-ref, etc.). The tdnf-installed packages composed into `dbgrd.cpio.gz`, `shell.cpio.gz`, `initrd`, `sdk/sysroot.tar.gz`, and `petritools.erofs` were not tracked anywhere.

## What changed

1. **`pkg/Tools/build.sh`** — drop `/var/lib/rpm` from the strip list. Still strip `var/cache/tdnf`, man pages, and docs.
2. **`pkg/Tools/gen-sboms.sh`** — new script that extracts each artifact and runs `syft scan` against it, emitting `out/sboms/<name>.spdx.json`.
3. **`azure-pipeline.yml`** — install syft (single Go binary) and run `gen-sboms.sh` after the docker build, before publishing artifacts.

The SBOMs ride along in the same pipeline artifact that already feeds the NuGet package, so downstream consumers pick them up automatically.

## Trade-offs

- **Size**: the RPM database adds a few MB per cpio.gz / tar.gz. The runtime rootfses (dbgrd, shell, initrd) get loaded into VTL2 memory, so this is real but small overhead -- intentional in exchange for accurate dependency tracking.
- **Build time**: ~1-2 minutes per platform for syft to scan all artifacts.
- **erofs**: `petritools.erofs` is currently skipped by `gen-sboms.sh` because syft doesn't read erofs natively; can be added later via `erofsdump` if needed.

## Testing

I'd appreciate a CI run to validate the syft step end-to-end. Locally I've checked the bash scripts parse and that the YAML structure is valid; the actual artifact scan has to happen on the Linux build agent.