### PR TITLE
linux/x86_64: build bzImage kernel

### DIFF
--- a/pkg/linux/build.sh
+++ b/pkg/linux/build.sh
@@ -14,8 +14,8 @@ esac
 
 case $KARCH in
     x86_64)
-        KTARGETS=vmlinux
-        KIMAGES="./vmlinux"
+        KTARGETS="vmlinux bzImage"
+        KIMAGES="./vmlinux ./arch/x86/boot/bzImage"
         ;;
     arm64)
         KTARGETS="vmlinux Image"


### PR DESCRIPTION
WSL uses the bzImage format for the kernel it ships with. To support WSL using OpenVMM as the backend, we need to extend OpenVMM to support direct boot with this format, which it currently does not. I have a draft PR that adds this support, but what good is a change without a test. To test this functionality, I need a bzImage formatted kernel that can be consumed from the OpenVMM VMM tests. This PR adds this version of the kernel to the openvmm-deps to be consumed during said tests. 