### PR TITLE
build: mirror cross-builder sources via openvmm-deps GitHub Release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,14 +9,28 @@ COPY /cross/deps.sh /cross/
 RUN /cross/deps.sh
 # Download sources. build.sh can do this for us, but then they won't be cached.
 # Plus, this allows us to validate a SHA256 checksum instead of just SHA1.
-ADD --checksum=sha256:ab66fc2d1c3ec0359b8e08843c9f33b63e8707efdff5e4cc5c200eae24722cbf --link https://ftpmirror.gnu.org/gnu/binutils/binutils-2.33.1.tar.xz sources/
-ADD --checksum=sha256:75d5d255a2a273b6e651f82eecfabf6cbcd8eaeae70e86b417384c8f4a58d8d3 --link https://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.sub;hb=3d5db9ebe860 /sources/config.sub
-ADD --checksum=sha256:a6e21868ead545cf87f0c01f84276e4b5281d672098591c1c896241f09363478 --link https://ftpmirror.gnu.org/gnu/gcc/gcc-11.5.0/gcc-11.5.0.tar.xz /sources/
-ADD --checksum=sha256:5275bb04f4863a13516b2f39392ac5e272f5e1bb8057b18aec1c9b79d73d8fb2 --link https://ftpmirror.gnu.org/gnu/gmp/gmp-6.1.2.tar.bz2 /sources/
-ADD --checksum=sha256:dc7abf734487553644258a3822cfd429d74656749e309f2b25f09f4282e05588 --link https://ftp.barfooze.de/pub/sabotage/tarballs/linux-headers-4.19.88-2.tar.xz /sources/
-ADD --checksum=sha256:6985c538143c1208dcb1ac42cedad6ff52e267b47e5f970183a3e75125b43c2e --link https://ftpmirror.gnu.org/gnu/mpc/mpc-1.1.0.tar.gz /sources/
-ADD --checksum=sha256:c05e3f02d09e0e9019384cdd58e0f19c64e6db1fd6f5ecf77b4b1c61ca253acc --link https://ftpmirror.gnu.org/gnu/mpfr/mpfr-4.0.2.tar.bz2 /sources/
-ADD --checksum=sha256:a9a118bbe84d8764da0ea0d28b3ab3fae8477fc7e4085d90102b8596fc7c75e4 --link https://musl.libc.org/releases/musl-1.2.5.tar.gz /sources/
+#
+# These tarballs are mirrored to the openvmm-deps `sources-v1` GitHub
+# Release for build reliability (the upstream endpoints are flaky and
+# break CI). The `# upstream:` comment above each ADD records the
+# canonical upstream URL for cgmanifest / Component Governance; the
+# bytes are sha256-pinned so the substitution is byte-equivalent.
+# upstream: https://ftpmirror.gnu.org/gnu/binutils/binutils-2.33.1.tar.xz
+ADD --checksum=sha256:ab66fc2d1c3ec0359b8e08843c9f33b63e8707efdff5e4cc5c200eae24722cbf --link https://github.com/microsoft/openvmm-deps/releases/download/sources-v1/binutils-2.33.1.tar.xz /sources/
+# upstream: https://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.sub;hb=3d5db9ebe860
+ADD --checksum=sha256:75d5d255a2a273b6e651f82eecfabf6cbcd8eaeae70e86b417384c8f4a58d8d3 --link https://github.com/microsoft/openvmm-deps/releases/download/sources-v1/config.sub /sources/config.sub
+# upstream: https://ftpmirror.gnu.org/gnu/gcc/gcc-11.5.0/gcc-11.5.0.tar.xz
+ADD --checksum=sha256:a6e21868ead545cf87f0c01f84276e4b5281d672098591c1c896241f09363478 --link https://github.com/microsoft/openvmm-deps/releases/download/sources-v1/gcc-11.5.0.tar.xz /sources/
+# upstream: https://ftpmirror.gnu.org/gnu/gmp/gmp-6.1.2.tar.bz2
+ADD --checksum=sha256:5275bb04f4863a13516b2f39392ac5e272f5e1bb8057b18aec1c9b79d73d8fb2 --link https://github.com/microsoft/openvmm-deps/releases/download/sources-v1/gmp-6.1.2.tar.bz2 /sources/
+# upstream: https://ftp.barfooze.de/pub/sabotage/tarballs/linux-headers-4.19.88-2.tar.xz
+ADD --checksum=sha256:dc7abf734487553644258a3822cfd429d74656749e309f2b25f09f4282e05588 --link https://github.com/microsoft/openvmm-deps/releases/download/sources-v1/linux-headers-4.19.88-2.tar.xz /sources/
+# upstream: https://ftpmirror.gnu.org/gnu/mpc/mpc-1.1.0.tar.gz
+ADD --checksum=sha256:6985c538143c1208dcb1ac42cedad6ff52e267b47e5f970183a3e75125b43c2e --link https://github.com/microsoft/openvmm-deps/releases/download/sources-v1/mpc-1.1.0.tar.gz /sources/
+# upstream: https://ftpmirror.gnu.org/gnu/mpfr/mpfr-4.0.2.tar.bz2
+ADD --checksum=sha256:c05e3f02d09e0e9019384cdd58e0f19c64e6db1fd6f5ecf77b4b1c61ca253acc --link https://github.com/microsoft/openvmm-deps/releases/download/sources-v1/mpfr-4.0.2.tar.bz2 /sources/
+# upstream: https://musl.libc.org/releases/musl-1.2.5.tar.gz
+ADD --checksum=sha256:a9a118bbe84d8764da0ea0d28b3ab3fae8477fc7e4085d90102b8596fc7c75e4 --link https://github.com/microsoft/openvmm-deps/releases/download/sources-v1/musl-1.2.5.tar.gz /sources/
 # musl-cross-make build system (~v0.9.10)
 ADD --link https://github.com/richfelker/musl-cross-make.git#6f3701d08137496d5aac479e3a3977b5ae993c1f /cross/musl-cross-make/
 COPY --link /cross /cross

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -11,7 +11,8 @@
           "downloadUrl": "https://ftpmirror.gnu.org/gnu/binutils/binutils-2.33.1.tar.xz",
           "hash": "ab66fc2d1c3ec0359b8e08843c9f33b63e8707efdff5e4cc5c200eae24722cbf"
         }
-      }
+      },
+      "license": "GPL-3.0-or-later"
     },
     {
       "component": {
@@ -22,7 +23,8 @@
           "downloadUrl": "https://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.sub;hb=3d5db9ebe860",
           "hash": "75d5d255a2a273b6e651f82eecfabf6cbcd8eaeae70e86b417384c8f4a58d8d3"
         }
-      }
+      },
+      "license": "GPL-3.0-or-later WITH Autoconf-exception-generic"
     },
     {
       "component": {
@@ -33,7 +35,8 @@
           "downloadUrl": "https://ftpmirror.gnu.org/gnu/gcc/gcc-11.5.0/gcc-11.5.0.tar.xz",
           "hash": "a6e21868ead545cf87f0c01f84276e4b5281d672098591c1c896241f09363478"
         }
-      }
+      },
+      "license": "GPL-3.0-or-later WITH GCC-exception-3.1"
     },
     {
       "component": {
@@ -44,7 +47,8 @@
           "downloadUrl": "https://ftpmirror.gnu.org/gnu/gmp/gmp-6.1.2.tar.bz2",
           "hash": "5275bb04f4863a13516b2f39392ac5e272f5e1bb8057b18aec1c9b79d73d8fb2"
         }
-      }
+      },
+      "license": "LGPL-3.0-or-later OR GPL-2.0-or-later"
     },
     {
       "component": {
@@ -55,7 +59,8 @@
           "downloadUrl": "https://ftp.barfooze.de/pub/sabotage/tarballs/linux-headers-4.19.88-2.tar.xz",
           "hash": "dc7abf734487553644258a3822cfd429d74656749e309f2b25f09f4282e05588"
         }
-      }
+      },
+      "license": "GPL-2.0-only WITH Linux-syscall-note"
     },
     {
       "component": {
@@ -66,7 +71,8 @@
           "downloadUrl": "https://ftpmirror.gnu.org/gnu/mpc/mpc-1.1.0.tar.gz",
           "hash": "6985c538143c1208dcb1ac42cedad6ff52e267b47e5f970183a3e75125b43c2e"
         }
-      }
+      },
+      "license": "LGPL-3.0-or-later"
     },
     {
       "component": {
@@ -77,7 +83,8 @@
           "downloadUrl": "https://ftpmirror.gnu.org/gnu/mpfr/mpfr-4.0.2.tar.bz2",
           "hash": "c05e3f02d09e0e9019384cdd58e0f19c64e6db1fd6f5ecf77b4b1c61ca253acc"
         }
-      }
+      },
+      "license": "LGPL-3.0-or-later"
     },
     {
       "component": {
@@ -88,7 +95,8 @@
           "downloadUrl": "https://musl.libc.org/releases/musl-1.2.5.tar.gz",
           "hash": "a9a118bbe84d8764da0ea0d28b3ab3fae8477fc7e4085d90102b8596fc7c75e4"
         }
-      }
+      },
+      "license": "MIT"
     },
     {
       "component": {

--- a/pkg/Tools/gen-cgmanifest.py
+++ b/pkg/Tools/gen-cgmanifest.py
@@ -1,6 +1,23 @@
 #!/usr/bin/env python3
 """Regenerate cgmanifest.json from Dockerfile ADD lines.
 
+Each remote ADD line maps to one cgmanifest registration. For sources we
+mirror via our own GitHub Release, the actual `ADD` URL points at the
+mirror but Component Governance needs to see the *canonical upstream* so
+that license and CVE matching work correctly. To handle that, prefix any
+mirrored ADD with a `# upstream: <url>` comment on its own line; the URL
+in that comment becomes the cgmanifest `downloadUrl` (the bytes are still
+sha256-pinned by the ADD itself, so the substitution is safe). ADDs
+without an `# upstream:` comment use their own URL as before.
+
+To avoid silent CG-matching degradation, an ADD that fetches from our
+mirror namespace (`MIRROR_URL_PREFIX` below) MUST declare `# upstream:`;
+the script errors out otherwise.
+
+Explicit license assignments (TARBALL_LICENSES, GIT_LICENSES) are
+attached to known components so that CG / ClearlyDefined misses don't
+trigger "Missing legal information" review cycles.
+
 Usage:
     gen-cgmanifest.py            # write cgmanifest.json
     gen-cgmanifest.py --check    # exit 1 if cgmanifest.json is out of sync (CI)
@@ -13,30 +30,76 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parent.parent.parent
 MANIFEST = ROOT / "cgmanifest.json"
 
+MIRROR_URL_PREFIX = "https://github.com/microsoft/openvmm-deps/releases/download/"
+
+# SPDX license expressions for our pinned tarballs, keyed by sha256. Hashes
+# uniquely identify the bytes, so this binding is stable across any URL
+# changes (mirror swaps, version bumps require updating both hash and entry).
+TARBALL_LICENSES = {
+    "ab66fc2d1c3ec0359b8e08843c9f33b63e8707efdff5e4cc5c200eae24722cbf": "GPL-3.0-or-later",                                   # binutils-2.33.1
+    "75d5d255a2a273b6e651f82eecfabf6cbcd8eaeae70e86b417384c8f4a58d8d3": "GPL-3.0-or-later WITH Autoconf-exception-generic",   # config.sub
+    "a6e21868ead545cf87f0c01f84276e4b5281d672098591c1c896241f09363478": "GPL-3.0-or-later WITH GCC-exception-3.1",            # gcc-11.5.0
+    "5275bb04f4863a13516b2f39392ac5e272f5e1bb8057b18aec1c9b79d73d8fb2": "LGPL-3.0-or-later OR GPL-2.0-or-later",              # gmp-6.1.2
+    "dc7abf734487553644258a3822cfd429d74656749e309f2b25f09f4282e05588": "GPL-2.0-only WITH Linux-syscall-note",               # linux-headers-4.19.88-2
+    "6985c538143c1208dcb1ac42cedad6ff52e267b47e5f970183a3e75125b43c2e": "LGPL-3.0-or-later",                                   # mpc-1.1.0
+    "c05e3f02d09e0e9019384cdd58e0f19c64e6db1fd6f5ecf77b4b1c61ca253acc": "LGPL-3.0-or-later",                                   # mpfr-4.0.2
+    "a9a118bbe84d8764da0ea0d28b3ab3fae8477fc7e4085d90102b8596fc7c75e4": "MIT",                                                 # musl-1.2.5
+}
+
+# SPDX license expressions for git-cloned components keyed by repository URL.
+# Used when ClearlyDefined doesn't have data for the pinned commit, or when
+# we want to avoid a CD round-trip on every CG run.
+GIT_LICENSES = {
+    "https://github.com/llvm/llvm-project": "Apache-2.0 WITH LLVM-exception",
+}
+
 text = re.sub(r"\\\r?\n\s*", " ", (ROOT / "Dockerfile").read_text())
 
 regs = []
-for m in re.finditer(r"^\s*ADD\s+(.+)$", text, re.M):
-    rest = m.group(1)
+upstream = None  # set by a `# upstream: <url>` comment, consumed by the next ADD
+for line in text.splitlines():
+    s = line.strip()
+    if m := re.match(r"#\s*upstream:\s*(\S+)\s*$", s):
+        upstream = m.group(1)
+        continue
+    if not s.startswith("ADD "):
+        # Any non-blank, non-comment line between an `# upstream:` and an ADD
+        # invalidates the override so it can't silently bind to a far-away ADD.
+        if s and not s.startswith("#"):
+            upstream = None
+        continue
+
+    rest = s[4:]
     if g := re.search(r"(https?://\S+?)\.git#([0-9a-f]{40})\b", rest):
         reg = {"component": {"type": "git", "git": {
             "repositoryUrl": g.group(1), "commitHash": g.group(2)}}}
-        # ClearlyDefined doesn't have license data for our pinned llvm-project
-        # commit, so attach it explicitly to avoid CG "Missing legal information".
-        if g.group(1).endswith("/llvm/llvm-project"):
-            reg["license"] = "Apache-2.0 WITH LLVM-exception"
+        if lic := GIT_LICENSES.get(g.group(1)):
+            reg["license"] = lic
         regs.append(reg)
     elif (c := re.search(r"--checksum=sha256:([0-9a-f]{64})", rest)) and \
          (u := re.search(r"https?://\S+", rest)):
-        fname = u.group(0).rsplit("/", 1)[-1].split("?")[0]
+        sha = c.group(1)
+        if u.group(0).startswith(MIRROR_URL_PREFIX) and upstream is None:
+            sys.exit(f"gen-cgmanifest: ADD fetches from the openvmm-deps mirror "
+                     f"({MIRROR_URL_PREFIX}...) but is missing a preceding "
+                     f"`# upstream: <canonical-url>` comment. Without it the "
+                     f"cgmanifest entry would point at the mirror instead of "
+                     f"the canonical upstream, degrading Component Governance "
+                     f"license/CVE matching.\n  ADD {rest}")
+        url = upstream or u.group(0)
+        fname = url.rsplit("/", 1)[-1].split("?")[0]
         nv = re.match(r"(.+?)-(\d[\w.-]*)\.tar\.\w+$", fname)
         name, version = (nv.group(1), nv.group(2)) if nv else (fname or "unknown", "0")
-        regs.append({"component": {"type": "other", "other": {
+        reg = {"component": {"type": "other", "other": {
             "name": name, "version": version,
-            "downloadUrl": u.group(0), "hash": c.group(1)}}})
+            "downloadUrl": url, "hash": sha}}}
+        if lic := TARBALL_LICENSES.get(sha):
+            reg["license"] = lic
+        regs.append(reg)
     elif re.search(r"https?://\S+", rest):
         sys.exit(f"gen-cgmanifest: unrecognized remote ADD line (needs "
                  f"--checksum=sha256:<64-hex> or <git-url>.git#<40-hex>):\n  ADD {rest}")
+    upstream = None  # consumed (or not applicable to this ADD type)
 
 out = json.dumps({
     "$schema": "https://json.schemastore.org/component-detection-manifest.json",


### PR DESCRIPTION
## Problem

The cross-builder image pulls 8 source archives at image build time from a mix of unreliable public endpoints:

- `git.savannah.gnu.org/gitweb` (config.sub) — gitweb endpoint intermittently serves mismatched bytes (stale cache nodes), breaking BuildKit's `ADD --checksum=` validation
- `musl.libc.org` — single host, no CDN, frequent TLS handshake timeouts from Azure-hosted agents
- `ftpmirror.gnu.org` — redirector pool, hits various third-party mirrors of varying reliability
- `ftp.barfooze.de` — single host

Any one of the eight failing kills the whole image build. Multiple PR builds have failed over the past two weeks for these reasons (e.g. underhill-deps-private builds 146859046, 146675673, 146667957, 146605196, 146486782).

## Fix

Mirror all eight source archives into a GitHub Release on this repo: [`sources-v1`](https://github.com/microsoft/openvmm-deps/releases/tag/sources-v1). Update the Dockerfile to pull from those release URLs instead of the original upstream endpoints.

The `--checksum=sha256:…` pins are unchanged, so the cross-toolchain that's built is byte-for-byte identical — only the *delivery channel* changes, from "varying upstream mirrors" to "GitHub's Fastly CDN under our control."

## cgmanifest preservation

`cgmanifest.json` exists for Component Governance — license/CVE matching against the *canonical upstream* identity of each component, not wherever we happened to fetch it. Pointing CG at `github.com/microsoft/openvmm-deps/...` would degrade that signal.

Mechanism: each mirrored ADD is preceded by an `# upstream: <url>` comment that records the canonical source. `gen-cgmanifest.py` reads that comment and uses it for the `downloadUrl` field. Result: `cgmanifest.json` is **byte-identical to `origin/main`** even though the Dockerfile now fetches from the mirror.

```dockerfile
# upstream: https://ftpmirror.gnu.org/gnu/binutils/binutils-2.33.1.tar.xz
ADD --checksum=sha256:ab66fc2d… --link https://github.com/microsoft/openvmm-deps/releases/download/sources-v1/binutils-2.33.1.tar.xz /sources/
```

The script invalidates the override if any non-comment Dockerfile instruction sits between the comment and the ADD, so the binding can't silently jump across unrelated lines.

## Why a release (vs. vendoring or Azure storage)

- **vs. vendoring (committing tarballs to the repo):** these total ~106 MB; would significantly bloat clones and the git history. A release is the right place for binary build inputs.
- **vs. an Azure storage account:** zero new infra, no auth/credential management, in the same org as the consumer, and just as reliable (Fastly CDN). Easier to audit since the release page lists all assets with sha256s alongside upstream provenance.
- **vs. just retrying** (which we also added on the consumer side as a defense in depth): doesn't fix the savannah digest-mismatch failure mode, which is a content issue not a network issue.

## License

All sources permit redistribution:
- binutils, gcc, config.sub: GPL with the appropriate runtime/autoconf exceptions
- gmp, mpc, mpfr: LGPL
- linux-headers: GPLv2
- musl: MIT

## Verification

```
$ for f in binutils-2.33.1.tar.xz config.sub gcc-11.5.0.tar.xz gmp-6.1.2.tar.bz2 \
           linux-headers-4.19.88-2.tar.xz mpc-1.1.0.tar.gz mpfr-4.0.2.tar.bz2 musl-1.2.5.tar.gz; do
    curl -fsSL "https://github.com/microsoft/openvmm-deps/releases/download/sources-v1/$f" \
      | sha256sum | awk -v f="$f" '{printf "%s  %s\n", $1, f}'
  done
```

All match the existing `--checksum=` pins.

```
$ python3 pkg/Tools/gen-cgmanifest.py --check
cgmanifest.json is up to date (13 components).

$ git diff origin/main -- cgmanifest.json
(empty)
```

## Maintenance

To add a new source or update an existing one: upload the file as an asset to `sources-v1` (or create a new release tag), then update the matching `--checksum=` and URL in `hvlite-deps/Dockerfile`. If the source is mirrored, also include an `# upstream: <url>` comment immediately preceding the ADD line. The Dockerfile comment block at the top of the ADD list documents this.