### PR TITLE
ci: update actions/checkout from v4 to v6 for Node.js 24 support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
   cgmanifest:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 1
 
@@ -29,7 +29,7 @@ jobs:
           - architecture: x86_64
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 1
 


### PR DESCRIPTION
Node.js 20 actions are deprecated and will be forced to Node.js 24 starting June 2nd, 2026. Update actions/checkout to v6 which natively supports Node.js 24.