### PR TITLE
ci: run Docker builds on a self-hosted 1ES runner pool

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,24 +25,53 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - architecture: aarch64
-          - architecture: x86_64
-    runs-on: ubuntu-latest
+        architecture: [aarch64, x86_64]
+    runs-on:
+      - self-hosted
+      - 1ES.Pool=openvmm-deps-gh-amd-westus2
+      - 1ES.ImageOverride=ubuntu2404-amd64
+      - JobId=build-${{ matrix.architecture }}-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 1
+
+      - name: Prepare Docker storage on resource SSD
+        # OS disk is small (~80GB); put the daemon's data-root on the ~1.2TB
+        # resource SSD at /mnt (root-owned), so pre-create a runner-writable dir.
+        run: sudo install -d -o "$(id -u)" -g "$(id -g)" /mnt/docker
+
+      - name: Determine Docker socket group
+        id: docker_socket_group
+        # dockerd runs as root and chowns its socket to the `docker` group, which
+        # is absent on this image, so the socket stays root-only and the action's
+        # readiness probe (non-root) fails. Use the runner's primary group instead.
+        run: echo "group=$(id -gn)" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker
+        uses: docker/setup-docker-action@v5
+        with:
+          version: "v29.0.0"
+          runtime-basedir: /mnt/docker
+          daemon-config: |
+            {
+              "group": "${{ steps.docker_socket_group.outputs.group }}"
+            }
 
       - name: Set up QEMU
         if: matrix.architecture == 'aarch64'
         uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
+        # Static engine has no buildx plugin and `docker build` isn't aliased to
+        # it here, so `--output type=local` needs an explicit `docker buildx build`.
         uses: docker/setup-buildx-action@v3
 
       - name: Build ${{ matrix.architecture }} outputs
-        run: docker build --platform "${{ matrix.architecture }}" --output type=local,dest=out .
+        run: docker buildx build --platform "${{ matrix.architecture }}" --output type=local,dest=out .
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Move the `build` job off `ubuntu-latest` onto the dedicated 1ES Hosted Pool `openvmm-deps-gh-amd-westus2` (image `ubuntu2404-amd64`). Both x86_64 and aarch64 share the AMD pool; aarch64 still cross-compiles via QEMU.

Fixes the recurring `No space left on device` flakes from the GitHub-hosted runners (e.g. [run 25928571548](https://github.com/microsoft/openvmm-deps/actions/runs/25928571548)) and gives us a project-owned scheduling pool.

Also a nice speedup — D32a has 32 vCPUs vs `ubuntu-latest`'s 4, and build I/O lands on a local 1.2TB SSD:

| arch    | old (`ubuntu-latest`, avg of 3 runs) | new (1ES `Standard_D32a`) | speedup |
| ------- | ------------------------------------ | ------------------------- | ------- |
| x86_64  | ~36 min                              | **9 min 20 s**            | ~3.9×   |
| aarch64 | ~43 min                              | **15 min 34 s**           | ~2.8×   |

## Docker setup

The 1ES image doesn't ship Docker, so the workflow sets it up itself:

- **Pinned engine.** `docker/setup-docker-action@v5` installs Docker `v29.0.0` with `runtime-basedir: /mnt/docker`, keeping the daemon's data-root on the ~1.2TB resource SSD. The OS disk is small (~80GB); without this, Docker 29's containerd snapshotter fills it and the runner agent gets killed mid-build with no log capture.
- **Socket group.** `dockerd` runs as root and chowns its unix socket to the `docker` group, which doesn't exist on this image — so the socket stays root-only and the action's non-root readiness probe fails. We set the socket group via `daemon-config` to the runner's primary group (always present and includes the runner user), making the socket usable without a root daemon socket exposed to everyone.
- **Buildx.** The static engine has no buildx plugin and `docker build` isn't aliased to buildx on self-hosted runners, so `--output type=local` would hit the legacy builder. We add `docker/setup-buildx-action` and build with an explicit `docker buildx build`.

Future improvement: bake Docker (and the `/mnt` storage layout) directly into the 1ES image so these steps can be dropped entirely.

`cgmanifest` and `release` stay on `ubuntu-latest` (small jobs, no benefit).
