### PR TITLE
Add virtio-win driver extraction build target

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,10 +50,29 @@ jobs:
           name: ${{ matrix.architecture }}
           path: out
 
+  build-virtio-win:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build virtio-win
+        run: docker build -f Dockerfile.virtio-win --output type=local,dest=out .
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: virtio-win
+          path: out
+
   release:
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
-    needs: [build]
+    needs: [build, build-virtio-win]
     permissions:
       contents: write
     steps:
@@ -66,6 +85,7 @@ jobs:
         run: |
           cd out
           mkdir package
+          VERSION="0.3.0-${{ github.run_number }}"
           # To add a new test kernel, extend KERNELS below and follow the
           # `## Adding a new kernel version` recipe in pkg/linux/README.md
           # (new src-/build-/result- Dockerfile stages, sysroots/linux-<ver>/deps,
@@ -73,15 +93,18 @@ jobs:
           # tarballs by glob, so no further workflow changes are required.
           KERNELS="6.1 6.18"
           for arch in x86_64 aarch64; do
-            tar cvzf "package/openvmm-deps.$arch.0.3.0-${{ github.run_number }}.tar.gz" \
+            tar cvzf "package/openvmm-deps.$arch.$VERSION.tar.gz" \
               -C "$arch/openvmm-deps" .
-            tar cvzf "package/openvmm-test-initrd.$arch.0.3.0-${{ github.run_number }}.tar.gz" \
+            tar cvzf "package/openvmm-test-initrd.$arch.$VERSION.tar.gz" \
               -C "$arch/initrd" .
             for kver in $KERNELS; do
-              tar cvzf "package/openvmm-test-linux-$kver.$arch.0.3.0-${{ github.run_number }}.tar.gz" \
+              tar cvzf "package/openvmm-test-linux-$kver.$arch.$VERSION.tar.gz" \
                 -C "$arch/linux-$kver" .
             done
           done
+          # virtio-win is arch-independent (Windows PE binaries).
+          tar cvzf "package/openvmm-test-virtio-win.$VERSION.tar.gz" \
+            -C virtio-win .
 
       - name: Create GitHub release
         env:

--- a/Dockerfile.virtio-win
+++ b/Dockerfile.virtio-win
@@ -1,0 +1,30 @@
+# syntax=docker/dockerfile:1
+#
+# Extract virtio-win drivers from the virtio-win ISO.
+# Currently extracts NetKVM only; add more driver families by extending the
+# grep filter below.
+#
+# This is architecture-independent (the ISO contains Windows PE binaries
+# for multiple guest architectures) and does not use the cross-compilation
+# toolchain from the main Dockerfile.
+
+ARG HOST_IMAGE=mcr.microsoft.com/azurelinux/base/core:3.0
+
+FROM $HOST_IMAGE AS build
+RUN tdnf install -y cdrkit && tdnf clean all
+
+# upstream: https://fedorapeople.org/groups/virt/virtio-win/direct-downloads/archive-virtio/virtio-win-0.1.285-1/virtio-win-0.1.285.iso
+ADD --checksum=sha256:e14cf2b94492c3e925f0070ba7fdfedeb2048c91eea9c5a5afb30232a3976331 \
+    https://github.com/microsoft/openvmm-deps/releases/download/virtio-iso-v1/virtio-win-0.1.285.iso \
+    /tmp/virtio-win.iso
+
+RUN set -e && \
+    for path in $(isoinfo -i /tmp/virtio-win.iso -f | grep '^/NetKVM/' | grep -v '\.pdb$' | grep -vi 'readme' | grep -E '\.[a-zA-Z]{2,}$'); do \
+      dir="/out$(dirname "$path")" && \
+      mkdir -p "$dir" && \
+      isoinfo -i /tmp/virtio-win.iso -x "$path" > "/out$path"; \
+    done && \
+    rm /tmp/virtio-win.iso
+
+FROM scratch AS output
+COPY --from=build /out/ /

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ The release pipeline packs each of these into its own tarball:
 | `openvmm-test-initrd.<arch>.<ver>.tar.gz`             | shared initrd (used with any kernel)  |
 | `openvmm-test-linux-6.1.<arch>.<ver>.tar.gz`          | 6.1 LTS kernel images + final config  |
 | `openvmm-test-linux-6.18.<arch>.<ver>.tar.gz`         | 6.18 kernel images + final config     |
+| `openvmm-test-virtio-win.<ver>.tar.gz`                | virtio-win NetKVM drivers (all OS/arch)|
 
 The `openvmm-deps` tarball no longer contains a kernel; consumers that
 need a Linux-direct boot kernel (e.g. petri's `Firmware::LinuxDirect`)
@@ -56,3 +57,24 @@ To build only one target (e.g. just a kernel) use `--target`:
 docker build --platform x86_64 --target result-linux-6.1 \
   --output type=local,dest=out/linux-6.1 .
 ```
+
+## virtio-win drivers
+
+A separate `Dockerfile.virtio-win` extracts Windows virtio drivers from
+the [virtio-win](https://github.com/virtio-win/virtio-win-pkg-scripts)
+ISO. This build is architecture-independent (the ISO contains Windows PE
+binaries for multiple guest architectures) and runs separately from the
+main cross-compilation pipeline.
+
+```bash
+docker build -f Dockerfile.virtio-win --output type=local,dest=out .
+```
+
+The output preserves the ISO's directory layout (e.g.
+`NetKVM/2k22/amd64/`, `NetKVM/2k25/ARM64/`). Currently only NetKVM
+drivers are extracted; to add more driver families, extend the `grep`
+filter in `Dockerfile.virtio-win`.
+
+The ISO is mirrored to the
+[`virtio-iso-v1`](https://github.com/microsoft/openvmm-deps/releases/tag/virtio-iso-v1)
+GitHub release, pinned by sha256 checksum.

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -152,6 +152,18 @@
           "commitHash": "748c20f1fc486beca1a2679ed06492712cfdc950"
         }
       }
+    },
+    {
+      "component": {
+        "type": "other",
+        "other": {
+          "name": "virtio-win",
+          "version": "0.1.285",
+          "downloadUrl": "https://fedorapeople.org/groups/virt/virtio-win/direct-downloads/archive-virtio/virtio-win-0.1.285-1/virtio-win-0.1.285.iso",
+          "hash": "e14cf2b94492c3e925f0070ba7fdfedeb2048c91eea9c5a5afb30232a3976331"
+        }
+      },
+      "license": "BSD-3-Clause"
     }
   ]
 }

--- a/pkg/Tools/gen-cgmanifest.py
+++ b/pkg/Tools/gen-cgmanifest.py
@@ -44,6 +44,7 @@ TARBALL_LICENSES = {
     "6985c538143c1208dcb1ac42cedad6ff52e267b47e5f970183a3e75125b43c2e": "LGPL-3.0-or-later",                                   # mpc-1.1.0
     "c05e3f02d09e0e9019384cdd58e0f19c64e6db1fd6f5ecf77b4b1c61ca253acc": "LGPL-3.0-or-later",                                   # mpfr-4.0.2
     "a9a118bbe84d8764da0ea0d28b3ab3fae8477fc7e4085d90102b8596fc7c75e4": "MIT",                                                 # musl-1.2.5
+    "e14cf2b94492c3e925f0070ba7fdfedeb2048c91eea9c5a5afb30232a3976331": "BSD-3-Clause",                                         # virtio-win-0.1.285
 }
 
 # SPDX license expressions for git-cloned components keyed by repository URL.
@@ -53,7 +54,11 @@ GIT_LICENSES = {
     "https://github.com/llvm/llvm-project": "Apache-2.0 WITH LLVM-exception",
 }
 
-text = re.sub(r"\\\r?\n\s*", " ", (ROOT / "Dockerfile").read_text())
+text = ""
+for dockerfile in ["Dockerfile", "Dockerfile.virtio-win"]:
+    p = ROOT / dockerfile
+    if p.exists():
+        text += re.sub(r"\\\r?\n\s*", " ", p.read_text()) + "\n"
 
 regs = []
 upstream = None  # set by a `# upstream: <url>` comment, consumed by the next ADD
@@ -88,7 +93,7 @@ for line in text.splitlines():
                      f"license/CVE matching.\n  ADD {rest}")
         url = upstream or u.group(0)
         fname = url.rsplit("/", 1)[-1].split("?")[0]
-        nv = re.match(r"(.+?)-(\d[\w.-]*)\.tar\.\w+$", fname)
+        nv = re.match(r"(.+?)-(\d[\w.-]*)\.(?:tar\.\w+|iso)$", fname)
         name, version = (nv.group(1), nv.group(2)) if nv else (fname or "unknown", "0")
         reg = {"component": {"type": "other", "other": {
             "name": name, "version": version,
@@ -107,7 +112,7 @@ out = json.dumps({
 
 if "--check" in sys.argv[1:]:
     if not MANIFEST.exists() or MANIFEST.read_text() != out:
-        sys.exit(f"{MANIFEST.name} is out of sync with Dockerfile; "
+        sys.exit(f"{MANIFEST.name} is out of sync with Dockerfiles; "
                  f"rerun pkg/Tools/gen-cgmanifest.py and commit the result.")
     print(f"{MANIFEST.name} is up to date ({len(regs)} components).")
 else:


### PR DESCRIPTION
Add a separate Dockerfile (Dockerfile.virtio-win) that downloads the virtio-win 0.1.285 ISO, extracts all NetKVM network driver files (minus PDBs) for every supported Windows version and guest architecture, and outputs them as a ~27MB artifact — avoiding the need to download the full 753MB ISO in downstream repos.

This is useful for testing virtio-net on Windows guests in the OpenVMM repo.

The ISO is mirrored to a new `virtio-iso-v1` GitHub release, pinned by sha256 checksum. Currently only NetKVM drivers are extracted; other driver families (viostor, vioscsi, etc.) can be added by extending the grep filter.