### PR TITLE
qemu: add statically-linked QEMU system emulators

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -101,7 +101,7 @@ jobs:
               tar cvzf "package/openvmm-test-linux-$kver.$arch.$VERSION.tar.gz" \
                 -C "$arch/linux-$kver" .
             done
-            tar cvzf "package/qemu-linux-static.$arch.0.3.0-${{ github.run_number }}.tar.gz" \
+            tar cvzf "package/qemu-linux-static.$arch.$VERSION.tar.gz" \
               -C "$arch/qemu" .
           done
           # virtio-win is arch-independent (Windows PE binaries).

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -101,6 +101,8 @@ jobs:
               tar cvzf "package/openvmm-test-linux-$kver.$arch.$VERSION.tar.gz" \
                 -C "$arch/linux-$kver" .
             done
+            tar cvzf "package/qemu-linux-static.$arch.0.3.0-${{ github.run_number }}.tar.gz" \
+              -C "$arch/qemu" .
           done
           # virtio-win is arch-independent (Windows PE binaries).
           tar cvzf "package/openvmm-test-virtio-win.$VERSION.tar.gz" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -95,6 +95,9 @@ ADD --link https://github.com/openssl/openssl.git#27315a978e280a20c7f3ea0bfe05f6
 # SymCrypt requires git metadata during its build
 FROM scratch AS src-symcrypt
 ADD --keep-git-dir=true --link https://github.com/microsoft/symcrypt.git#748c20f1fc486beca1a2679ed06492712cfdc950 /
+# qemu (v11.0.1)
+FROM scratch AS src-qemu
+ADD --keep-git-dir=true --link https://github.com/qemu/qemu.git#6e9a825c1d4e7b62d072e99a89ecd1a74c7f0d55 /
 
 # Build the sdk.
 #
@@ -155,6 +158,19 @@ RUN BUILD_EROFS=1 /pkg/Tools/build.sh sysroots/petritools
 FROM scratch AS result-petritools
 COPY --from=build-petritools --link /out/sysroot.erofs /petritools.erofs
 
+# Build QEMU (statically linked, TCG only).
+# Uses Ubuntu for multiarch cross-compilation support.
+FROM --platform=$BUILDPLATFORM ubuntu:24.04 AS build-qemu
+ARG TARGETARCH
+ENV TARGETARCH=$TARGETARCH
+COPY --link pkg/qemu/deps.sh /pkg/qemu/deps.sh
+RUN /pkg/qemu/deps.sh
+COPY --link pkg/qemu /pkg/qemu
+RUN --mount=type=bind,from=src-qemu,source=/,target=/pkg/qemu/src,rw \
+    cd /pkg/qemu/src && /pkg/qemu/patch.sh && /pkg/qemu/build.sh
+FROM scratch AS result-qemu
+COPY --from=build-qemu --link /out/ /
+
 # Build the output. The release workflow packs each top-level subdirectory
 # into its own GitHub release artifact:
 #   openvmm-deps/  -> openvmm-deps.<arch>.<release>.tar.gz
@@ -168,3 +184,4 @@ COPY --from=result-petritools --link / /openvmm-deps/
 COPY --from=result-initrd     --link /initrd /initrd/initrd
 COPY --from=result-linux-6.1  --link / /linux-6.1/
 COPY --from=result-linux-6.18 --link / /linux-6.18/
+COPY --from=result-qemu       --link / /qemu/

--- a/Dockerfile
+++ b/Dockerfile
@@ -97,7 +97,7 @@ FROM scratch AS src-symcrypt
 ADD --keep-git-dir=true --link https://github.com/microsoft/symcrypt.git#748c20f1fc486beca1a2679ed06492712cfdc950 /
 # qemu (v11.0.1)
 FROM scratch AS src-qemu
-ADD --keep-git-dir=true --link https://github.com/qemu/qemu.git#6e9a825c1d4e7b62d072e99a89ecd1a74c7f0d55 /
+ADD --checksum=sha256:b3c66db81b337ef296b838066d41ec479ea2172e795ee113cb30c1f982b9ca39 --link https://github.com/qemu/qemu/archive/refs/tags/v11.0.1.tar.gz /
 
 # Build the sdk.
 #
@@ -166,7 +166,7 @@ ENV TARGETARCH=$TARGETARCH
 COPY --link pkg/qemu/deps.sh /pkg/qemu/deps.sh
 RUN /pkg/qemu/deps.sh
 COPY --link pkg/qemu /pkg/qemu
-RUN --mount=type=bind,from=src-qemu,source=/,target=/pkg/qemu/src,rw \
+RUN --mount=type=bind,from=src-qemu,source=/qemu-11.0.1,target=/pkg/qemu/src,rw \
     cd /pkg/qemu/src && /pkg/qemu/patch.sh && /pkg/qemu/build.sh
 FROM scratch AS result-qemu
 COPY --from=build-qemu --link /out/ /

--- a/Dockerfile
+++ b/Dockerfile
@@ -97,7 +97,7 @@ FROM scratch AS src-symcrypt
 ADD --keep-git-dir=true --link https://github.com/microsoft/symcrypt.git#748c20f1fc486beca1a2679ed06492712cfdc950 /
 # qemu (v11.0.1)
 FROM scratch AS src-qemu
-ADD --checksum=sha256:b3c66db81b337ef296b838066d41ec479ea2172e795ee113cb30c1f982b9ca39 --link https://github.com/qemu/qemu/archive/refs/tags/v11.0.1.tar.gz /
+ADD --unpack --checksum=sha256:b3c66db81b337ef296b838066d41ec479ea2172e795ee113cb30c1f982b9ca39 --link https://github.com/qemu/qemu/archive/refs/tags/v11.0.1.tar.gz /
 
 # Build the sdk.
 #

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ out/
   initrd/              shared busybox-based test rootfs (cpio.gz)
   linux-6.1/           vmlinux, bzImage/Image, config (kernel only)
   linux-6.18/          vmlinux, bzImage/Image, config (kernel only)
+  qemu/                qemu-system-aarch64, qemu-system-x86_64
 ```
 
 The release pipeline packs each of these into its own tarball:
@@ -37,6 +38,7 @@ The release pipeline packs each of these into its own tarball:
 | `openvmm-test-linux-6.1.<arch>.<ver>.tar.gz`          | 6.1 LTS kernel images + final config  |
 | `openvmm-test-linux-6.18.<arch>.<ver>.tar.gz`         | 6.18 kernel images + final config     |
 | `openvmm-test-virtio-win.<ver>.tar.gz`                | virtio-win NetKVM drivers (all OS/arch)|
+| `qemu-linux-static.<arch>.<ver>.tar.gz`                | static QEMU system emulators (TCG)    |
 
 The `openvmm-deps` tarball no longer contains a kernel; consumers that
 need a Linux-direct boot kernel (e.g. petri's `Firmware::LinuxDirect`)

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -155,10 +155,12 @@
     },
     {
       "component": {
-        "type": "git",
-        "git": {
-          "repositoryUrl": "https://github.com/qemu/qemu",
-          "commitHash": "6e9a825c1d4e7b62d072e99a89ecd1a74c7f0d55"
+        "type": "other",
+        "other": {
+          "name": "qemu",
+          "version": "11.0.1",
+          "downloadUrl": "https://github.com/qemu/qemu/archive/refs/tags/v11.0.1.tar.gz",
+          "hash": "b3c66db81b337ef296b838066d41ec479ea2172e795ee113cb30c1f982b9ca39"
         }
       }
     },

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -155,6 +155,15 @@
     },
     {
       "component": {
+        "type": "git",
+        "git": {
+          "repositoryUrl": "https://github.com/qemu/qemu",
+          "commitHash": "6e9a825c1d4e7b62d072e99a89ecd1a74c7f0d55"
+        }
+      }
+    },
+    {
+      "component": {
         "type": "other",
         "other": {
           "name": "virtio-win",

--- a/pkg/Tools/gen-cgmanifest.py
+++ b/pkg/Tools/gen-cgmanifest.py
@@ -94,7 +94,15 @@ for line in text.splitlines():
         url = upstream or u.group(0)
         fname = url.rsplit("/", 1)[-1].split("?")[0]
         nv = re.match(r"(.+?)-(\d[\w.-]*)\.(?:tar\.\w+|iso)$", fname)
-        name, version = (nv.group(1), nv.group(2)) if nv else (fname or "unknown", "0")
+        if not nv:
+            # Try GitHub archive URLs: .../qemu/archive/refs/tags/v11.0.1.tar.gz
+            # Extract name from the repo path and version from the tag.
+            if m2 := re.match(r"https?://github\.com/([^/]+/([^/]+))/archive/refs/tags/v?([\w.-]+)\.tar\.gz$", url):
+                name, version = m2.group(2), m2.group(3)
+            else:
+                name, version = fname or "unknown", "0"
+        else:
+            name, version = nv.group(1), nv.group(2)
         reg = {"component": {"type": "other", "other": {
             "name": name, "version": version,
             "downloadUrl": url, "hash": sha}}}

--- a/pkg/qemu/0001-hw-arm-smmuv3-Advertise-FWB-capability-in-IDR3.patch
+++ b/pkg/qemu/0001-hw-arm-smmuv3-Advertise-FWB-capability-in-IDR3.patch
@@ -1,0 +1,34 @@
+From: John Starks <jostarks@microsoft.com>
+Date: Wed, 4 Jun 2026 00:00:00 +0000
+Subject: [PATCH] hw/arm/smmuv3: Advertise FWB capability in IDR3
+
+Set the FWB (Force Write-Back) bit in IDR3 when stage-2 translation
+is supported. FWB allows stage-2 page tables to override stage-1
+memory type and cacheability attributes, forcing write-back
+cacheability on stage-1 output.
+
+The Linux kernel requires FWB support for iommufd nested translation.
+Without this bit, the kernel refuses to enable nesting on the
+emulated SMMUv3.
+
+This is just useful for testing purposes and probably should not
+be included upstream without additional thought.
+---
+ hw/arm/smmuv3.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/hw/arm/smmuv3.c b/hw/arm/smmuv3.c
+index 5c2855c377..cf6c1495c7 100644
+--- a/hw/arm/smmuv3.c
++++ b/hw/arm/smmuv3.c
+@@ -304,6 +304,9 @@ static void smmuv3_init_id_regs(SMMUv3State *s)
+     if (FIELD_EX32(s->idr[0], IDR0, S2P)) {
+         /* XNX is a stage-2-specific feature */
+         s->idr[3] = FIELD_DP32(s->idr[3], IDR3, XNX, 1);
++        /* FWB: S2 can force write-back cacheability on S1 output.
++         * Required by the Linux kernel for iommufd nested translation. */
++        s->idr[3] = FIELD_DP32(s->idr[3], IDR3, FWB, 1);
+     }
+     s->idr[3] = FIELD_DP32(s->idr[3], IDR3, RIL, 1);
+     s->idr[3] = FIELD_DP32(s->idr[3], IDR3, BBML, 2);
+-- 

--- a/pkg/qemu/build.sh
+++ b/pkg/qemu/build.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# Build statically-linked QEMU system emulators (TCG only, no accelerators).
+# Supports both native and cross-compilation via $TARGETARCH.
+
+set -e
+
+SRCDIR="${SRCDIR:-/pkg/qemu/src}"
+BUILDDIR="${BUILDDIR:-/work/qemu}"
+OUTPUTDIR="${OUTPUTDIR:-/out}"
+
+# Determine if we need to cross-compile.
+HOST_ARCH=$(uname -m)
+case "${TARGETARCH:-}" in
+    arm64)  TARGET_ARCH=aarch64 ;;
+    amd64)  TARGET_ARCH=x86_64 ;;
+    *)      TARGET_ARCH="$HOST_ARCH" ;;
+esac
+
+CROSS_OPTS=()
+if [ "$TARGET_ARCH" != "$HOST_ARCH" ]; then
+    CROSS_OPTS+=(--cross-prefix="${TARGET_ARCH}-linux-gnu-")
+fi
+
+mkdir -p "$BUILDDIR" "$OUTPUTDIR"
+cd "$BUILDDIR"
+
+"$SRCDIR/configure" \
+    "${CROSS_OPTS[@]}" \
+    --target-list=aarch64-softmmu,x86_64-softmmu \
+    --static \
+    --without-default-features \
+    --enable-system \
+    --enable-tcg \
+    --enable-fdt=internal \
+    --enable-slirp \
+    --disable-pixman \
+    --disable-docs \
+    --disable-install-blobs \
+    -Ddefault_library=static
+
+make -j$(nproc)
+
+for bin in qemu-system-aarch64 qemu-system-x86_64; do
+    install -Dm755 "$BUILDDIR/$bin" "$OUTPUTDIR/$bin"
+    "${TARGET_ARCH}-linux-gnu-strip" "$OUTPUTDIR/$bin" 2>/dev/null \
+        || strip "$OUTPUTDIR/$bin"
+done

--- a/pkg/qemu/deps.sh
+++ b/pkg/qemu/deps.sh
@@ -32,11 +32,11 @@ if [ "$CROSS_ARCH" != "$HOST_ARCH" ]; then
     if [ "$HOST_ARCH" = "amd64" ]; then
         CROSS_GCC=gcc-aarch64-linux-gnu
         CROSS_LIBC=libc6-dev-arm64-cross
-        PORTS_URI=http://ports.ubuntu.com/
+        PORTS_URI=https://ports.ubuntu.com/
     else
         CROSS_GCC=gcc-x86-64-linux-gnu
         CROSS_LIBC=libc6-dev-amd64-cross
-        PORTS_URI=http://archive.ubuntu.com/ubuntu
+        PORTS_URI=https://archive.ubuntu.com/ubuntu
     fi
 
     sed -i "/^Types:/a Architectures: $HOST_ARCH" /etc/apt/sources.list.d/ubuntu.sources

--- a/pkg/qemu/deps.sh
+++ b/pkg/qemu/deps.sh
@@ -6,6 +6,9 @@ set -e
 
 export DEBIAN_FRONTEND=noninteractive
 
+HOST_ARCH=$(dpkg --print-architecture)
+CROSS_ARCH="${TARGETARCH:-$HOST_ARCH}"
+
 PACKAGES="
     gcc
     make
@@ -13,17 +16,14 @@ PACKAGES="
     python3
     python3-venv
     pkg-config
-    libglib2.0-dev
-    zlib1g-dev
+    libglib2.0-dev:$CROSS_ARCH
+    zlib1g-dev:$CROSS_ARCH
     flex
     bison
     git
     ca-certificates
     patch
 "
-
-HOST_ARCH=$(dpkg --print-architecture)
-CROSS_ARCH="${TARGETARCH:-$HOST_ARCH}"
 
 if [ "$CROSS_ARCH" != "$HOST_ARCH" ]; then
     dpkg --add-architecture "$CROSS_ARCH"
@@ -50,12 +50,7 @@ Architectures: $CROSS_ARCH
 Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
 EOF
 
-    PACKAGES="$PACKAGES
-        $CROSS_GCC
-        $CROSS_LIBC
-        libglib2.0-dev:$CROSS_ARCH
-        zlib1g-dev:$CROSS_ARCH
-    "
+    PACKAGES="$PACKAGES $CROSS_GCC $CROSS_LIBC"
 fi
 
 apt-get update

--- a/pkg/qemu/deps.sh
+++ b/pkg/qemu/deps.sh
@@ -19,6 +19,7 @@ PACKAGES="
     bison
     git
     ca-certificates
+    patch
 "
 
 HOST_ARCH=$(dpkg --print-architecture)

--- a/pkg/qemu/deps.sh
+++ b/pkg/qemu/deps.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+# Install host dependencies for building QEMU.
+# Handles multiarch setup for cross-compilation when TARGETARCH != host.
+
+set -e
+
+export DEBIAN_FRONTEND=noninteractive
+
+PACKAGES="
+    gcc
+    make
+    ninja-build
+    python3
+    python3-venv
+    pkg-config
+    libglib2.0-dev
+    zlib1g-dev
+    flex
+    bison
+    git
+    ca-certificates
+"
+
+HOST_ARCH=$(dpkg --print-architecture)
+CROSS_ARCH="${TARGETARCH:-$HOST_ARCH}"
+
+if [ "$CROSS_ARCH" != "$HOST_ARCH" ]; then
+    dpkg --add-architecture "$CROSS_ARCH"
+
+    # On Ubuntu, non-native architectures need the ports mirror.
+    # Pin existing repos to the host arch, then add ports for the cross arch.
+    if [ "$HOST_ARCH" = "amd64" ]; then
+        CROSS_GCC=gcc-aarch64-linux-gnu
+        CROSS_LIBC=libc6-dev-arm64-cross
+        PORTS_URI=http://ports.ubuntu.com/
+    else
+        CROSS_GCC=gcc-x86-64-linux-gnu
+        CROSS_LIBC=libc6-dev-amd64-cross
+        PORTS_URI=http://archive.ubuntu.com/ubuntu
+    fi
+
+    sed -i "/^Types:/a Architectures: $HOST_ARCH" /etc/apt/sources.list.d/ubuntu.sources
+    cat > /etc/apt/sources.list.d/ubuntu-ports.sources <<EOF
+Types: deb
+URIs: $PORTS_URI
+Suites: noble noble-updates noble-security
+Components: main universe
+Architectures: $CROSS_ARCH
+Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
+EOF
+
+    PACKAGES="$PACKAGES
+        $CROSS_GCC
+        $CROSS_LIBC
+        libglib2.0-dev:$CROSS_ARCH
+        zlib1g-dev:$CROSS_ARCH
+    "
+fi
+
+apt-get update
+apt-get install -y --no-install-recommends $PACKAGES

--- a/pkg/qemu/deps.sh
+++ b/pkg/qemu/deps.sh
@@ -16,15 +16,19 @@ PACKAGES="
     python3
     python3-venv
     pkg-config
+    libglib2.0-dev:$HOST_ARCH
     libglib2.0-dev:$CROSS_ARCH
     zlib1g-dev:$CROSS_ARCH
     flex
     bison
     git
     patch
+
 "
 
 if [ "$CROSS_ARCH" != "$HOST_ARCH" ]; then
+    apt-get update
+    apt-get install -y ca-certificates
     dpkg --add-architecture "$CROSS_ARCH"
 
     # On Ubuntu, non-native architectures need the ports mirror.
@@ -50,8 +54,6 @@ Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
 EOF
 
     PACKAGES="$PACKAGES $CROSS_GCC $CROSS_LIBC"
-    apt-get update
-    apt-get install -y ca-certificates
 fi
 
 apt-get update

--- a/pkg/qemu/deps.sh
+++ b/pkg/qemu/deps.sh
@@ -21,7 +21,6 @@ PACKAGES="
     flex
     bison
     git
-    ca-certificates
     patch
 "
 
@@ -51,6 +50,8 @@ Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
 EOF
 
     PACKAGES="$PACKAGES $CROSS_GCC $CROSS_LIBC"
+    apt-get update
+    apt-get install -y ca-certificates
 fi
 
 apt-get update

--- a/pkg/qemu/patch.sh
+++ b/pkg/qemu/patch.sh
@@ -5,8 +5,9 @@ set -e
 
 cd "${SRCDIR:-/pkg/qemu/src}"
 
+PKGDIR="${PKGDIR:-$(dirname "$0")}"
 for p in "$PKGDIR"/*.patch; do
     [ -f "$p" ] || continue
     echo "Applying $(basename "$p")"
-    git apply "$p"
+    patch -p1 < "$p"
 done

--- a/pkg/qemu/patch.sh
+++ b/pkg/qemu/patch.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# Apply patches to the QEMU source tree.
+# Called from the Dockerfile before build.sh.
+set -e
+
+cd "${SRCDIR:-/pkg/qemu/src}"
+
+for p in "$PKGDIR"/*.patch; do
+    [ -f "$p" ] || continue
+    echo "Applying $(basename "$p")"
+    git apply "$p"
+done


### PR DESCRIPTION
Build statically-linked qemu-system-aarch64 and qemu-system-x86_64 binaries (v11.0.1) with TCG and slirp networking. No accelerators, display, or blobs are included.

A pinned QEMU build ensures consistent behavior across developer machines. These will be used to run openvmm nested in QEMU, enabling CI testing of hardware-specific features (device assignment via VFIO, SMMU stage 1 hardware acceleration) without requiring physical lab hardware.

The build uses Ubuntu 24.04 as its base (rather than Azure Linux) to leverage multiarch support for cross-compilation. Both x86_64 and aarch64 host binaries are produced, with aarch64 cross-compiled from x86_64.

Includes a patch to advertise FWB capability in SMMUv3 IDR3, which is required for SMMU nested translation to work.