### PR TITLE
qemu: enable virtio-9p

### DIFF
--- a/pkg/qemu/build.sh
+++ b/pkg/qemu/build.sh
@@ -33,6 +33,7 @@ cd "$BUILDDIR"
     --enable-tcg \
     --enable-fdt=internal \
     --enable-slirp \
+    --enable-virtfs \
     --disable-pixman \
     --disable-docs \
     --disable-install-blobs \

--- a/pkg/qemu/build.sh
+++ b/pkg/qemu/build.sh
@@ -33,6 +33,7 @@ cd "$BUILDDIR"
     --enable-tcg \
     --enable-fdt=internal \
     --enable-slirp \
+    --enable-attr \
     --enable-virtfs \
     --disable-pixman \
     --disable-docs \

--- a/pkg/qemu/deps.sh
+++ b/pkg/qemu/deps.sh
@@ -19,6 +19,7 @@ PACKAGES="
     libglib2.0-dev:$HOST_ARCH
     libglib2.0-dev:$CROSS_ARCH
     zlib1g-dev:$CROSS_ARCH
+    libattr1-dev:$CROSS_ARCH
     flex
     bison
     git


### PR DESCRIPTION
Add the appropriate build flags to enable virtio-9p support in qemu.