### PR TITLE
Build the oss TPM

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,9 +39,6 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Free disk space
-        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
-
       - name: Set up QEMU
         if: matrix.architecture == 'aarch64'
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
           fetch-depth: 1
 
       - name: Free disk space
-        uses: jlumbroso/free-disk-space@main
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
 
       - name: Set up QEMU
         if: matrix.architecture == 'aarch64'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,6 +34,9 @@ jobs:
         with:
           fetch-depth: 1
 
+      - name: Free disk space
+        uses: jlumbroso/free-disk-space@main
+
       - name: Set up QEMU
         if: matrix.architecture == 'aarch64'
         uses: docker/setup-qemu-action@v3

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,7 @@ COPY pkg/Tools/deps.sh /pkg/Tools/
 RUN /pkg/Tools/deps.sh
 COPY --link pkg /pkg
 COPY --link sysroots /sysroots
-ENV PATH="${PATH}:/opt/cross/bin"
+ENV PATH="${PATH}:/opt/cross/bin:/root/.cargo/bin"
 ENV SYSROOT="/sysroot"
 ARG TARGETARCH
 ENV TARGETARCH=$TARGETARCH
@@ -95,6 +95,12 @@ ADD --link https://github.com/openssl/openssl.git#27315a978e280a20c7f3ea0bfe05f6
 # SymCrypt requires git metadata during its build
 FROM scratch AS src-symcrypt
 ADD --keep-git-dir=true --link https://github.com/microsoft/symcrypt.git#cc7902403ec3e53df9cd0f25f5775c762ca7ccb5 /
+# ms-tpm-20-ref-rs (pinned by commit)
+FROM scratch AS src-ms-tpm-20-ref-rs
+ADD --link https://github.com/microsoft/ms-tpm-20-ref-rs.git#e0bba1e46d9cdc8630f3693e5e91f8a3be4fad7b /
+# ms-tpm-20-ref (pinned by commit)
+FROM scratch AS src-ms-tpm-20-ref
+ADD --link https://github.com/microsoft/ms-tpm-20-ref.git#2d5660ac249293dcbaed192c70ca208d321ebf5b /
 # qemu (v11.0.1)
 FROM scratch AS src-qemu
 ADD --unpack --checksum=sha256:b3c66db81b337ef296b838066d41ec479ea2172e795ee113cb30c1f982b9ca39 --link https://github.com/qemu/qemu/archive/refs/tags/v11.0.1.tar.gz /
@@ -108,6 +114,8 @@ RUN ln -s /opt/cross/*-linux-musl /sysroot
 RUN --mount=type=bind,from=src-llvm,source=/,target=/pkg/libunwind/src \
     --mount=type=bind,from=src-openssl,source=/,target=/pkg/openssl3/src,rw \
     --mount=type=bind,from=src-symcrypt,source=/,target=/pkg/symcrypt/src,rw \
+    --mount=type=bind,from=src-ms-tpm-20-ref-rs,source=/,target=/pkg/ms_tpm_20_ref/src,rw \
+    --mount=type=bind,from=src-ms-tpm-20-ref,source=/,target=/pkg/ms_tpm_20_ref/src/ms-tpm-20-ref,rw \
     /pkg/Tools/build.sh sysroots/sdk
 FROM scratch AS result-sdk
 COPY --from=build-sdk --link /out/sysroot.tar.gz /sysroot.tar.gz

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -155,6 +155,24 @@
     },
     {
       "component": {
+        "type": "git",
+        "git": {
+          "repositoryUrl": "https://github.com/microsoft/ms-tpm-20-ref-rs",
+          "commitHash": "e0bba1e46d9cdc8630f3693e5e91f8a3be4fad7b"
+        }
+      }
+    },
+    {
+      "component": {
+        "type": "git",
+        "git": {
+          "repositoryUrl": "https://github.com/microsoft/ms-tpm-20-ref",
+          "commitHash": "2d5660ac249293dcbaed192c70ca208d321ebf5b"
+        }
+      }
+    },
+    {
+      "component": {
         "type": "other",
         "other": {
           "name": "qemu",

--- a/pkg/Tools/build.sh
+++ b/pkg/Tools/build.sh
@@ -68,11 +68,16 @@ fi
 # Ensure build dependencies are all installed.
 "$TOOLSDIR/deps.sh"
 
+# Shared cargo setup for any rust-based packages
+cp "$TOOLSDIR/cargo.config.toml" /root/.cargo/config.toml
+export CARGO_BUILD_TARGET="$ARCH-unknown-linux-musl"
+
 for pkg in "${pkgs[@]}"; do
     PKGDIR=$(realpath "$pkg")
     export PKGDIR
     export SRCDIR="$PKGDIR/src"
     export BUILDDIR="/work/$pkg"
+    export CARGO_TARGET_DIR="$BUILDDIR/target"
 
     if [[ -f "$PKGDIR/patch.sh" && ! -f "$PKGDIR/.patched" ]]; then
         (

--- a/pkg/Tools/cargo.config.toml
+++ b/pkg/Tools/cargo.config.toml
@@ -1,0 +1,13 @@
+[env]
+# cc-rs picks per-target CC/AR env vars.
+CC_x86_64_unknown_linux_musl  = "x86_64-linux-musl-gcc"
+AR_x86_64_unknown_linux_musl  = "x86_64-linux-musl-ar"
+CC_aarch64_unknown_linux_musl = "aarch64-linux-musl-gcc"
+AR_aarch64_unknown_linux_musl = "aarch64-linux-musl-ar"
+
+# Point openssl-sys at the openssl built by pkg/openssl3 (already
+# installed into $SYSROOT, which is /sysroot in the package-builder
+# image) instead of letting it pull in a vendored copy.
+OPENSSL_DIR       = "/sysroot"
+OPENSSL_NO_VENDOR = "1"
+OPENSSL_STATIC    = "1"

--- a/pkg/Tools/deps.sh
+++ b/pkg/Tools/deps.sh
@@ -44,12 +44,12 @@ RUST_TOOLCHAIN="1.95.0"
 
 case "$(uname -m)" in
     x86_64)
-        rustup_arch="x86_64-unknown-linux-musl"
-        rustup_init_sha256="9cd3fda5fd293890e36ab271af6a786ee22084b5f6c2b83fd8323cec6f0992c1"
+        rustup_arch="x86_64-unknown-linux-gnu"
+        rustup_init_sha256="4acc9acc76d5079515b46346a485974457b5a79893cfb01112423c89aeb5aa10"
         ;;
     aarch64)
-        rustup_arch="aarch64-unknown-linux-musl"
-        rustup_init_sha256="88761caacddb92cd79b0b1f939f3990ba1997d701a38b3e8dd6746a562f2a759"
+        rustup_arch="aarch64-unknown-linux-gnu"
+        rustup_init_sha256="9732d6c5e2a098d3521fca8145d826ae0aaa067ef2385ead08e6feac88fa5792"
         ;;
     *)
         echo "unsupported host architecture: $(uname -m)" >&2

--- a/pkg/Tools/deps.sh
+++ b/pkg/Tools/deps.sh
@@ -39,7 +39,30 @@ util-linux
 
 tdnf install -y $packages
 
-curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- \
-    -y --no-modify-path --default-toolchain stable --profile minimal \
+RUSTUP_VERSION="1.29.0"
+RUST_TOOLCHAIN="1.96.0"
+
+case "$(uname -m)" in
+    x86_64)
+        rustup_arch="x86_64-unknown-linux-musl"
+        rustup_init_sha256="9cd3fda5fd293890e36ab271af6a786ee22084b5f6c2b83fd8323cec6f0992c1"
+        ;;
+    aarch64)
+        rustup_arch="aarch64-unknown-linux-musl"
+        rustup_init_sha256="88761caacddb92cd79b0b1f939f3990ba1997d701a38b3e8dd6746a562f2a759"
+        ;;
+    *)
+        echo "unsupported host architecture: $(uname -m)" >&2
+        exit 1
+        ;;
+esac
+
+curl --proto '=https' --tlsv1.2 -sSfo /tmp/rustup-init \
+    "https://static.rust-lang.org/rustup/archive/${RUSTUP_VERSION}/${rustup_arch}/rustup-init"
+echo "${rustup_init_sha256}  /tmp/rustup-init" | sha256sum -c -
+chmod +x /tmp/rustup-init
+/tmp/rustup-init \
+    -y --no-modify-path --default-toolchain "$RUST_TOOLCHAIN" --profile minimal \
     --target x86_64-unknown-linux-musl \
     --target aarch64-unknown-linux-musl
+rm /tmp/rustup-init

--- a/pkg/Tools/deps.sh
+++ b/pkg/Tools/deps.sh
@@ -40,7 +40,7 @@ util-linux
 tdnf install -y $packages
 
 RUSTUP_VERSION="1.29.0"
-RUST_TOOLCHAIN="1.96.0"
+RUST_TOOLCHAIN="1.95.0"
 
 case "$(uname -m)" in
     x86_64)

--- a/pkg/Tools/deps.sh
+++ b/pkg/Tools/deps.sh
@@ -11,7 +11,9 @@ bash
 bc
 binutils
 bison
+ca-certificates
 cmake
+curl
 diffutils
 elfutils-libelf-devel
 erofs-utils
@@ -36,3 +38,8 @@ util-linux
 "
 
 tdnf install -y $packages
+
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- \
+    -y --no-modify-path --default-toolchain stable --profile minimal \
+    --target x86_64-unknown-linux-musl \
+    --target aarch64-unknown-linux-musl

--- a/pkg/ms_tpm_20_ref/build.sh
+++ b/pkg/ms_tpm_20_ref/build.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+set -e
+
+# Build libtpm.a by invoking `ms-tpm-20-ref-rs`'s own `build.rs` via
+# cargo, so the C source list, overrides, compile flags, and defines
+# all live in the upstream wrapper crate -- not duplicated here.
+#
+# `cargo check` is sufficient as it still runs the build script to
+# produce libtpm.a as a side-effect.
+cd "$SRCDIR"
+cargo check --release --locked
+
+# `build.rs` writes libtpm.a under `OUT_DIR/ms-tpm-20-ref/`.
+LIBTPM=$(find "$CARGO_TARGET_DIR/$CARGO_BUILD_TARGET/release/build" -path '*/ms-tpm-20-ref-*/out/ms-tpm-20-ref/libtpm.a' -print -quit)
+
+install -d "$SYSROOT/tpm-oss-openssl/lib"
+install -m 644 "$LIBTPM" "$SYSROOT/tpm-oss-openssl/lib/libtpm.a"

--- a/sysroots/sdk/deps
+++ b/sysroots/sdk/deps
@@ -11,3 +11,4 @@ CXXFLAGS=$CXXFLAGS -fno-omit-frame-pointer -Os
 pkg/libunwind
 pkg/openssl3
 pkg/symcrypt
+pkg/ms_tpm_20_ref


### PR DESCRIPTION
Build the opensource ms-tpm-20-ref libtpm.a and vendor it in the SDK. In order to not duplicate build logic from the rust crate this adds support for building Rust to the whole build process, then simply builds the crate and copies the final .a file out of it.