### PR TITLE
ci: run Docker builds on a self-hosted 1ES runner pool

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,10 +25,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - architecture: aarch64
-          - architecture: x86_64
-    runs-on: ubuntu-latest
+        architecture: [aarch64, x86_64]
+    runs-on:
+      - self-hosted
+      - 1ES.Pool=openvmm-deps-gh-amd-westus2
+      - 1ES.ImageOverride=ubuntu2404-amd64-docker
+      - JobId=build-${{ matrix.architecture }}-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v6
         with:
@@ -42,7 +47,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Build ${{ matrix.architecture }} outputs
-        run: docker build --platform "${{ matrix.architecture }}" --output type=local,dest=out .
+        run: docker buildx build --platform "${{ matrix.architecture }}" --output type=local,dest=out .
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Move the `build` job off `ubuntu-latest` onto the dedicated 1ES Hosted Pool `openvmm-deps-gh-amd-westus2`, using the prebaked **`ubuntu2404-amd64-docker`** image (Docker preinstalled). Both x86_64 and aarch64 share the AMD pool; aarch64 still cross-compiles via QEMU.

Fixes the recurring `No space left on device` flakes from the GitHub-hosted runners and gives us a project-owned scheduling pool. Also a nice speedup, since the 1ES SKU has far more vCPUs than `ubuntu-latest` (4 vCPUs) and build I/O lands on a large local SSD.

Because the image ships Docker preinstalled, the workflow stays minimal: no in-workflow engine install, no data-root/socket-group setup. It only sets up QEMU + buildx and builds via `docker buildx build`.

This supersedes #63, which achieved the same pool move on the plain `ubuntu2404-amd64` image and therefore had to install and configure Docker itself (pinned engine, `/mnt` data-root, socket-group workaround). Using the prebaked image realizes the "bake Docker into the 1ES image" future improvement called out there.

`cgmanifest`, `build-virtio-win`, and `release` stay on `ubuntu-latest` (small jobs, no benefit).