### PR TITLE
Update TPM, include libruncommand.a

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -97,7 +97,7 @@ FROM scratch AS src-symcrypt
 ADD --keep-git-dir=true --link https://github.com/microsoft/symcrypt.git#cc7902403ec3e53df9cd0f25f5775c762ca7ccb5 /
 # ms-tpm-20-ref-rs (pinned by commit)
 FROM scratch AS src-ms-tpm-20-ref-rs
-ADD --link https://github.com/microsoft/ms-tpm-20-ref-rs.git#e0bba1e46d9cdc8630f3693e5e91f8a3be4fad7b /
+ADD --link https://github.com/microsoft/ms-tpm-20-ref-rs.git#07a121e4b46659cdfa8711740c6622728adffd65 /
 # ms-tpm-20-ref (pinned by commit)
 FROM scratch AS src-ms-tpm-20-ref
 ADD --link https://github.com/microsoft/ms-tpm-20-ref.git#2d5660ac249293dcbaed192c70ca208d321ebf5b /

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -158,7 +158,7 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/microsoft/ms-tpm-20-ref-rs",
-          "commitHash": "e0bba1e46d9cdc8630f3693e5e91f8a3be4fad7b"
+          "commitHash": "07a121e4b46659cdfa8711740c6622728adffd65"
         }
       }
     },

--- a/pkg/ms_tpm_20_ref/build.sh
+++ b/pkg/ms_tpm_20_ref/build.sh
@@ -16,3 +16,4 @@ LIBTPM=$(find "$CARGO_TARGET_DIR/$CARGO_BUILD_TARGET/release/build" -path '*/ms-
 
 install -d "$SYSROOT/tpm-oss-openssl/lib"
 install -m 644 "$LIBTPM" "$SYSROOT/tpm-oss-openssl/lib/libtpm.a"
+install -m 644 "$LIBTPM" "$SYSROOT/tpm-oss-openssl/lib/ilbruncommand.a"

--- a/pkg/ms_tpm_20_ref/build.sh
+++ b/pkg/ms_tpm_20_ref/build.sh
@@ -11,9 +11,11 @@ set -e
 cd "$SRCDIR"
 cargo check --release --locked
 
-# `build.rs` writes libtpm.a under `OUT_DIR/ms-tpm-20-ref/`.
+# `build.rs` writes libtpm.a under `OUT_DIR/ms-tpm-20-ref/`, and
+# librun_command.a directly under `OUT_DIR/`.
 LIBTPM=$(find "$CARGO_TARGET_DIR/$CARGO_BUILD_TARGET/release/build" -path '*/ms-tpm-20-ref-*/out/ms-tpm-20-ref/libtpm.a' -print -quit)
+LIBRUNCOMMAND=$(find "$CARGO_TARGET_DIR/$CARGO_BUILD_TARGET/release/build" -path '*/ms-tpm-20-ref-*/out/librun_command.a' -print -quit)
 
 install -d "$SYSROOT/tpm-oss-openssl/lib"
 install -m 644 "$LIBTPM" "$SYSROOT/tpm-oss-openssl/lib/libtpm.a"
-install -m 644 "$LIBTPM" "$SYSROOT/tpm-oss-openssl/lib/ilbruncommand.a"
+install -m 644 "$LIBRUNCOMMAND" "$SYSROOT/tpm-oss-openssl/lib/librun_command.a"


### PR DESCRIPTION
This is needed for us to be able to set CC_FORCE_DISABLE in OpenHCL builds.