### PR TITLE
ms_tpm_20_ref: bump ms-tpm-20-ref-rs to dfKey OOB fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -100,7 +100,7 @@ FROM scratch AS src-symcrypt
 ADD --keep-git-dir=true --link https://github.com/microsoft/symcrypt.git#cc7902403ec3e53df9cd0f25f5775c762ca7ccb5 /
 # ms-tpm-20-ref-rs (pinned by commit)
 FROM scratch AS src-ms-tpm-20-ref-rs
-ADD --link https://github.com/microsoft/ms-tpm-20-ref-rs.git#07a121e4b46659cdfa8711740c6622728adffd65 /
+ADD --link https://github.com/microsoft/ms-tpm-20-ref-rs.git#9a24154df7b09cd1a0b90f25a7bf9cbb16e24c7d /
 # ms-tpm-20-ref (pinned by commit)
 FROM scratch AS src-ms-tpm-20-ref
 ADD --link https://github.com/microsoft/ms-tpm-20-ref.git#2d5660ac249293dcbaed192c70ca208d321ebf5b /

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -167,7 +167,7 @@
         "type": "git",
         "git": {
           "repositoryUrl": "https://github.com/microsoft/ms-tpm-20-ref-rs",
-          "commitHash": "07a121e4b46659cdfa8711740c6622728adffd65"
+          "commitHash": "9a24154df7b09cd1a0b90f25a7bf9cbb16e24c7d"
         }
       }
     },


### PR DESCRIPTION
Bump the pinned ms-tpm-20-ref-rs commit from 07a121e to 9a24154 (microsoft/ms-tpm-20-ref-rs#12) so the prebuilt tpm-oss-openssl libtpm.a is rebuilt with the radix-dependent dfKey out-of-bounds read fix in DfStart. Without this, the 64-bit-radix OSS OpenSSL build reads 16 bytes of uninitialized stack into the AES-256 key schedule, yielding a non-deterministic derivation-function output and a different vTPM AK on every boot.