### PR TITLE
Add virtio-villain guest binaries to the build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -129,6 +129,9 @@ jobs:
             fi
             tar cvzf "package/qemu-linux-static.$arch.$VERSION.tar.gz" \
               -C "$arch/qemu" .
+            # virtio-villain guest binaries (both arches).
+            tar cvzf "package/openvmm-test-virtio-villain.$arch.$VERSION.tar.gz" \
+              -C "$arch/virtio-villain" .
           done
           # virtio-win is arch-independent (Windows PE binaries).
           tar cvzf "package/openvmm-test-virtio-win.$VERSION.tar.gz" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -134,6 +134,10 @@ ADD --keep-git-dir=true --link https://github.com/laurencelundblade/t_cose.git#1
 # Arm GNU Toolchain 13.3.rel1, required by TF-RMM.
 FROM scratch AS src-arm-gnu-toolchain-aarch64-none-elf
 ADD --unpack --checksum=sha256:7fedf894040580b1db747d06ac5d4263c46e591ffe7695656d1da5accb00a159 --link https://developer.arm.com/-/media/Files/downloads/gnu/13.3.rel1/binrel/arm-gnu-toolchain-13.3.rel1-x86_64-aarch64-none-elf.tar.xz /
+# virtio-villain -- guest-side virtio protocol conformance/fault-injection
+# suite. Pinned to the v0.6.0 release commit.
+FROM scratch AS src-virtio-villain
+ADD --link https://github.com/weltling/virtio-villain.git#ce7886f63ec5f6a7ee8215b3517a3f3c42f42ea4 /
 
 # Build the sdk.
 #
@@ -160,6 +164,17 @@ COPY --from=base-initrd --link /sysroot /sysroot
 RUN BUILD_CPIO=1 /pkg/Tools/build.sh sysroots/initrd
 FROM scratch AS result-initrd
 COPY --from=build-initrd --link /out/sysroot.cpio.gz /initrd
+
+# Build virtio-villain: cross-compile the static musl `init`, pack it into a
+# cpio initramfs (BUILD_CPIO, like the initrd package), and dump the test
+# registry TSV (via binfmt/qemu-user). Uses the shared musl cross toolchain
+# from package-builder.
+FROM --platform=$BUILDPLATFORM package-builder AS build-virtio-villain
+RUN --mount=type=bind,from=src-virtio-villain,source=/,target=/pkg/virtio-villain/src \
+    BUILD_CPIO=1 /pkg/Tools/build.sh pkg/virtio-villain
+FROM scratch AS result-virtio-villain
+COPY --from=build-virtio-villain --link /out/sysroot.cpio.gz /initramfs.cpio.gz
+COPY --from=build-virtio-villain --link /out/tests.tsv /tests.tsv
 
 # Build the Linux test kernels. One stage per kernel version; each stage
 # bind-mounts its pinned source and reads its config from
@@ -260,6 +275,7 @@ COPY --from=build-tfa-cca --link /out/ /
 #   linux-<kver>/  -> openvmm-test-linux-<kver>.<arch>.<release>.tar.gz
 #   rmm-<rver>/    -> openvmm-test-rmm-<rver>.<arch>.<release>.tar.gz
 #   tfa-<tver>/    -> openvmm-test-tfa-<tver>.<arch>.<release>.tar.gz
+#   virtio-villain/ -> openvmm-test-virtio-villain.<arch>.<release>.tar.gz
 FROM scratch AS output-base
 COPY --from=result-dbgrd      --link / /openvmm-deps/
 COPY --from=result-shell      --link / /openvmm-deps/
@@ -269,6 +285,9 @@ COPY --from=result-initrd     --link /initrd /initrd/initrd
 COPY --from=result-linux-6.1  --link / /linux-6.1/
 COPY --from=result-linux-6.18 --link / /linux-6.18/
 COPY --from=result-qemu       --link / /qemu/
+# virtio-villain guest binaries. The cross-built `init` is packed into the
+# initramfs and run under binfmt/qemu-user to dump tests.tsv.
+COPY --from=result-virtio-villain --link / /virtio-villain/
 
 FROM scratch AS output-aarch64
 COPY --from=output-base       --link / /

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ out/
   rmm-cca/             rmm.img and debug artifacts (aarch64 output only)
   tfa-cca/             flash.bin and debug artifacts (aarch64 output only)
   qemu/                qemu-system-aarch64, qemu-system-x86_64
+  virtio-villain/      initramfs.cpio.gz, tests.tsv
 ```
 
 The release pipeline packs each of these into its own tarball:
@@ -44,6 +45,7 @@ The release pipeline packs each of these into its own tarball:
 | `openvmm-test-rmm-cca.aarch64.<ver>.tar.gz`             | TF-RMM firmware for QEMU virt CCA tests |
 | `openvmm-test-tfa-cca.aarch64.<ver>.tar.gz`             | TF-A firmware for Linux-direct QEMU virt CCA tests |
 | `openvmm-test-virtio-win.<ver>.tar.gz`                | virtio-win NetKVM drivers (all OS/arch)|
+| `openvmm-test-virtio-villain.<arch>.<ver>.tar.gz`     | virtio-villain guest initramfs + `tests.tsv` |
 | `qemu-linux-static.<arch>.<ver>.tar.gz`                | static QEMU system emulators (TCG)    |
 
 The `openvmm-deps` tarball no longer contains a kernel; consumers that

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -297,6 +297,16 @@
     },
     {
       "component": {
+        "type": "git",
+        "git": {
+          "repositoryUrl": "https://github.com/weltling/virtio-villain",
+          "commitHash": "ce7886f63ec5f6a7ee8215b3517a3f3c42f42ea4"
+        }
+      },
+      "license": "Apache-2.0"
+    },
+    {
+      "component": {
         "type": "other",
         "other": {
           "name": "virtio-win",

--- a/pkg/Tools/gen-cgmanifest.py
+++ b/pkg/Tools/gen-cgmanifest.py
@@ -53,6 +53,7 @@ TARBALL_LICENSES = {
 # we want to avoid a CD round-trip on every CG run.
 GIT_LICENSES = {
     "https://github.com/llvm/llvm-project": "Apache-2.0 WITH LLVM-exception",
+    "https://github.com/weltling/virtio-villain": "Apache-2.0",
 }
 
 text = ""

--- a/pkg/virtio-villain/build.sh
+++ b/pkg/virtio-villain/build.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+# Build virtio-villain's static musl `init` as a tiny initramfs and dump the
+# machine-readable test registry (tests.tsv) consumed by openvmm's
+# virtio_villain_tests. Driven by pkg/Tools/build.sh, which exports ARCH,
+# SRCDIR, SYSROOT, BUILDDIR, OUTPUTDIR and packs $SYSROOT into
+# sysroot.cpio.gz (BUILD_CPIO=1), the same way the initrd package does.
+
+set -e
+
+# Cross-build the static init with the musl toolchain (on PATH).
+make -C "$SRCDIR" TARGET="$BUILDDIR" CC="$ARCH-linux-musl-gcc"
+
+# Install it as the initramfs /init, next to the mountpoints init mounts
+# itself (/proc, /sys, /dev). The framework cpio-packs $SYSROOT.
+install -Dm755 "$BUILDDIR/init" "$SYSROOT/init"
+"$ARCH-linux-musl-strip" "$SYSROOT/init"
+mkdir -p "$SYSROOT/proc" "$SYSROOT/sys" "$SYSROOT/dev"
+
+# `init --list-tsv` runs on the build host (binfmt/qemu-user for cross
+# targets) and dumps the test registry as TSV.
+"$SYSROOT/init" --list-tsv > "$OUTPUTDIR/tests.tsv"
+echo "wrote $(wc -l < "$OUTPUTDIR/tests.tsv") test rows to tests.tsv"


### PR DESCRIPTION
Cross-compile the virtio-villain guest test suite (v0.6.0) for both x86_64 and aarch64 as a framework-driven package, producing an initramfs.cpio.gz plus a tests.tsv registry dump used to enumerate individual conformance tests. The package installs villain's static musl init into the sysroot and lets the build framework pack the cpio, following the existing initrd convention. Wired into the release workflow, cgmanifest, and README.