### PR TITLE
build: package release archives in Docker

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,13 +46,18 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Build ${{ matrix.architecture }} outputs
+      - name: Build ${{ matrix.architecture }} packages
         run: |
-          target=output
+          target=packages-x86_64
           if [ "${{ matrix.architecture }}" = "aarch64" ]; then
-            target=output-aarch64
+            target=packages-aarch64
           fi
-          docker buildx build --platform "${{ matrix.architecture }}" --target "$target" --output type=local,dest=out .
+          docker buildx build \
+            --platform "${{ matrix.architecture }}" \
+            --target "$target" \
+            --build-arg VERSION="0.3.0-${{ github.run_number }}" \
+            --output type=local,dest=out \
+            .
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
@@ -70,8 +75,14 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Build virtio-win
-        run: docker build -f Dockerfile.virtio-win --output type=local,dest=out .
+      - name: Build virtio-win package
+        run: |
+          docker buildx build \
+            -f Dockerfile.virtio-win \
+            --target packages \
+            --build-arg VERSION="0.3.0-${{ github.run_number }}" \
+            --output type=local,dest=out \
+            .
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
@@ -91,52 +102,6 @@ jobs:
         with:
           path: out
 
-      - name: Build package
-        run: |
-          cd out
-          mkdir package
-          VERSION="0.3.0-${{ github.run_number }}"
-          # To add a new test kernel, extend KERNELS below and follow the
-          # `## Adding a new kernel version` recipe in pkg/linux/README.md
-          # (new src-/build-/result- Dockerfile stages, sysroots/linux-<ver>/deps,
-          # configs, cgmanifest refresh).
-          KERNELS="6.1 6.18"
-          AARCH64_KERNELS="kvm-cca-dev"
-          AARCH64_RMMS="cca"
-          AARCH64_TFAS="cca"
-          for arch in x86_64 aarch64; do
-            tar cvzf "package/openvmm-deps.$arch.$VERSION.tar.gz" \
-              -C "$arch/openvmm-deps" .
-            tar cvzf "package/openvmm-test-initrd.$arch.$VERSION.tar.gz" \
-              -C "$arch/initrd" .
-            arch_kernels="$KERNELS"
-            if [ "$arch" = "aarch64" ]; then
-              arch_kernels="$arch_kernels $AARCH64_KERNELS"
-            fi
-            for kver in $arch_kernels; do
-              tar cvzf "package/openvmm-test-linux-$kver.$arch.$VERSION.tar.gz" \
-                -C "$arch/linux-$kver" .
-            done
-            if [ "$arch" = "aarch64" ]; then
-              for rver in $AARCH64_RMMS; do
-                tar cvzf "package/openvmm-test-rmm-$rver.$arch.$VERSION.tar.gz" \
-                  -C "$arch/rmm-$rver" .
-              done
-              for tver in $AARCH64_TFAS; do
-                tar cvzf "package/openvmm-test-tfa-$tver.$arch.$VERSION.tar.gz" \
-                  -C "$arch/tfa-$tver" .
-              done
-            fi
-            tar cvzf "package/qemu-linux-static.$arch.$VERSION.tar.gz" \
-              -C "$arch/qemu" .
-            # virtio-villain guest binaries (both arches).
-            tar cvzf "package/openvmm-test-virtio-villain.$arch.$VERSION.tar.gz" \
-              -C "$arch/virtio-villain" .
-          done
-          # virtio-win is arch-independent (Windows PE binaries).
-          tar cvzf "package/openvmm-test-virtio-win.$VERSION.tar.gz" \
-            -C virtio-win .
-
       - name: Create GitHub release
         env:
           GH_TOKEN: ${{ github.token }}
@@ -146,4 +111,4 @@ jobs:
             --title "$VERSION" \
             --generate-notes \
             --repo "$GITHUB_REPOSITORY" \
-            out/package/*.tar.gz
+            out/*/*.tar.gz

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,9 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 env:
-  VERSION: "0.3.0-${{ github.run_number }}"
+  # Preserve the release series used by the existing publishing workflow.
+  # Increment this prefix only when intentionally starting a new series.
+  RELEASE_VERSION_PREFIX: "0.3.0"
 
 jobs:
   cgmanifest:
@@ -51,6 +53,7 @@ jobs:
 
       - name: Build ${{ matrix.architecture }} packages
         run: |
+          VERSION="$RELEASE_VERSION_PREFIX-$GITHUB_RUN_NUMBER"
           target=packages-x86_64
           if [ "${{ matrix.architecture }}" = "aarch64" ]; then
             target=packages-aarch64
@@ -80,6 +83,7 @@ jobs:
 
       - name: Build virtio-win package
         run: |
+          VERSION="$RELEASE_VERSION_PREFIX-$GITHUB_RUN_NUMBER"
           docker buildx build \
             -f Dockerfile.virtio-win \
             --target packages \
@@ -109,6 +113,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          VERSION="$RELEASE_VERSION_PREFIX-$GITHUB_RUN_NUMBER"
           gh release create "$VERSION" \
             --title "$VERSION" \
             --generate-notes \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
+env:
+  VERSION: "0.3.0-${{ github.run_number }}"
+
 jobs:
   cgmanifest:
     runs-on: ubuntu-latest
@@ -55,7 +58,7 @@ jobs:
           docker buildx build \
             --platform "${{ matrix.architecture }}" \
             --target "$target" \
-            --build-arg VERSION="0.3.0-${{ github.run_number }}" \
+            --build-arg VERSION="$VERSION" \
             --output type=local,dest=out \
             .
 
@@ -80,7 +83,7 @@ jobs:
           docker buildx build \
             -f Dockerfile.virtio-win \
             --target packages \
-            --build-arg VERSION="0.3.0-${{ github.run_number }}" \
+            --build-arg VERSION="$VERSION" \
             --output type=local,dest=out \
             .
 
@@ -105,7 +108,6 @@ jobs:
       - name: Create GitHub release
         env:
           GH_TOKEN: ${{ github.token }}
-          VERSION: "0.3.0-${{ github.run_number }}"
         run: |
           gh release create "$VERSION" \
             --title "$VERSION" \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,9 +11,9 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 env:
-  # Preserve the release series used by the existing publishing workflow.
-  # Increment this prefix only when intentionally starting a new series.
-  RELEASE_VERSION_PREFIX: "0.3.0"
+  # Preserve the existing 0.3.0 release series. Increment only when
+  # intentionally starting a new series.
+  VERSION: "0.3.0-${{ github.run_number }}"
 
 jobs:
   cgmanifest:
@@ -53,7 +53,6 @@ jobs:
 
       - name: Build ${{ matrix.architecture }} packages
         run: |
-          VERSION="$RELEASE_VERSION_PREFIX-$GITHUB_RUN_NUMBER"
           target=packages-x86_64
           if [ "${{ matrix.architecture }}" = "aarch64" ]; then
             target=packages-aarch64
@@ -83,7 +82,6 @@ jobs:
 
       - name: Build virtio-win package
         run: |
-          VERSION="$RELEASE_VERSION_PREFIX-$GITHUB_RUN_NUMBER"
           docker buildx build \
             -f Dockerfile.virtio-win \
             --target packages \
@@ -113,7 +111,6 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          VERSION="$RELEASE_VERSION_PREFIX-$GITHUB_RUN_NUMBER"
           gh release create "$VERSION" \
             --title "$VERSION" \
             --generate-notes \

--- a/Dockerfile
+++ b/Dockerfile
@@ -295,15 +295,12 @@ COPY --from=result-linux-kvm-cca-dev --link / /linux-kvm-cca-dev/
 COPY --from=result-rmm-cca --link / /rmm-cca/
 COPY --from=result-tfa-cca --link / /tfa-cca/
 
-FROM scratch AS output
-COPY --from=output-base       --link / /
-
 # Package the output directories into the exact archives uploaded by the
 # release workflow. Keep packaging inside the Docker graph so PR and release
 # builds use the same immutable inputs.
 FROM --platform=$BUILDPLATFORM ubuntu:24.04 AS package-x86_64
 ARG VERSION
-COPY --from=output --link / /input/
+COPY --from=output-base --link / /input/
 RUN case "$VERSION" in \
         ""|*[!A-Za-z0-9._-]*) echo "invalid VERSION: $VERSION" >&2; exit 1 ;; \
     esac && \
@@ -352,3 +349,7 @@ RUN case "$VERSION" in \
     archive "openvmm-test-virtio-villain.aarch64.$VERSION.tar.gz" /input/virtio-villain
 FROM scratch AS packages-aarch64
 COPY --from=package-aarch64 --link /package/ /
+
+# Keep the unpacked output as the default target for local `docker build`.
+FROM scratch AS output
+COPY --from=output-base       --link / /

--- a/Dockerfile
+++ b/Dockerfile
@@ -297,3 +297,58 @@ COPY --from=result-tfa-cca --link / /tfa-cca/
 
 FROM scratch AS output
 COPY --from=output-base       --link / /
+
+# Package the output directories into the exact archives uploaded by the
+# release workflow. Keep packaging inside the Docker graph so PR and release
+# builds use the same immutable inputs.
+FROM --platform=$BUILDPLATFORM ubuntu:24.04 AS package-x86_64
+ARG VERSION
+COPY --from=output --link / /input/
+RUN case "$VERSION" in \
+        ""|*[!A-Za-z0-9._-]*) echo "invalid VERSION: $VERSION" >&2; exit 1 ;; \
+    esac && \
+    mkdir /package && \
+    archive() { \
+        name=$1; source=$2; \
+        temporary="/tmp/${name%.gz}"; \
+        tar --sort=name --mtime=@0 --owner=0 --group=0 --numeric-owner \
+            -C "$source" -cf "$temporary" . && \
+        gzip -n -c "$temporary" >"/package/$name" && \
+        rm "$temporary"; \
+    } && \
+    archive "openvmm-deps.x86_64.$VERSION.tar.gz" /input/openvmm-deps && \
+    archive "openvmm-test-initrd.x86_64.$VERSION.tar.gz" /input/initrd && \
+    archive "openvmm-test-linux-6.1.x86_64.$VERSION.tar.gz" /input/linux-6.1 && \
+    archive "openvmm-test-linux-6.18.x86_64.$VERSION.tar.gz" /input/linux-6.18 && \
+    archive "qemu-linux-static.x86_64.$VERSION.tar.gz" /input/qemu && \
+    archive "openvmm-test-virtio-villain.x86_64.$VERSION.tar.gz" /input/virtio-villain
+FROM scratch AS packages-x86_64
+COPY --from=package-x86_64 --link /package/ /
+
+FROM --platform=$BUILDPLATFORM ubuntu:24.04 AS package-aarch64
+ARG VERSION
+COPY --from=output-aarch64 --link / /input/
+RUN case "$VERSION" in \
+        ""|*[!A-Za-z0-9._-]*) echo "invalid VERSION: $VERSION" >&2; exit 1 ;; \
+    esac && \
+    mkdir /package && \
+    archive() { \
+        name=$1; source=$2; \
+        temporary="/tmp/${name%.gz}"; \
+        tar --sort=name --mtime=@0 --owner=0 --group=0 --numeric-owner \
+            -C "$source" -cf "$temporary" . && \
+        gzip -n -c "$temporary" >"/package/$name" && \
+        rm "$temporary"; \
+    } && \
+    archive "openvmm-deps.aarch64.$VERSION.tar.gz" /input/openvmm-deps && \
+    archive "openvmm-test-initrd.aarch64.$VERSION.tar.gz" /input/initrd && \
+    archive "openvmm-test-linux-6.1.aarch64.$VERSION.tar.gz" /input/linux-6.1 && \
+    archive "openvmm-test-linux-6.18.aarch64.$VERSION.tar.gz" /input/linux-6.18 && \
+    archive "openvmm-test-linux-kvm-cca-dev.aarch64.$VERSION.tar.gz" \
+        /input/linux-kvm-cca-dev && \
+    archive "openvmm-test-rmm-cca.aarch64.$VERSION.tar.gz" /input/rmm-cca && \
+    archive "openvmm-test-tfa-cca.aarch64.$VERSION.tar.gz" /input/tfa-cca && \
+    archive "qemu-linux-static.aarch64.$VERSION.tar.gz" /input/qemu && \
+    archive "openvmm-test-virtio-villain.aarch64.$VERSION.tar.gz" /input/virtio-villain
+FROM scratch AS packages-aarch64
+COPY --from=package-aarch64 --link /package/ /

--- a/Dockerfile.virtio-win
+++ b/Dockerfile.virtio-win
@@ -26,12 +26,9 @@ RUN set -e && \
     done && \
     rm /tmp/virtio-win.iso
 
-FROM scratch AS output
-COPY --from=build /out/ /
-
 FROM --platform=$BUILDPLATFORM ubuntu:24.04 AS package
 ARG VERSION
-COPY --from=output / /input/
+COPY --from=build /out/ /input/
 RUN case "$VERSION" in \
         ""|*[!A-Za-z0-9._-]*) echo "invalid VERSION: $VERSION" >&2; exit 1 ;; \
     esac && \
@@ -45,3 +42,7 @@ RUN case "$VERSION" in \
 
 FROM scratch AS packages
 COPY --from=package /package/ /
+
+# Keep the extracted driver layout as the default local build output.
+FROM scratch AS output
+COPY --from=build /out/ /

--- a/Dockerfile.virtio-win
+++ b/Dockerfile.virtio-win
@@ -28,3 +28,20 @@ RUN set -e && \
 
 FROM scratch AS output
 COPY --from=build /out/ /
+
+FROM --platform=$BUILDPLATFORM ubuntu:24.04 AS package
+ARG VERSION
+COPY --from=output / /input/
+RUN case "$VERSION" in \
+        ""|*[!A-Za-z0-9._-]*) echo "invalid VERSION: $VERSION" >&2; exit 1 ;; \
+    esac && \
+    mkdir /package && \
+    temporary=/tmp/openvmm-test-virtio-win.tar && \
+    tar --sort=name --mtime=@0 --owner=0 --group=0 --numeric-owner \
+        -C /input -cf "$temporary" . && \
+    gzip -n -c "$temporary" \
+        >"/package/openvmm-test-virtio-win.$VERSION.tar.gz" && \
+    rm "$temporary"
+
+FROM scratch AS packages
+COPY --from=package /package/ /

--- a/README.md
+++ b/README.md
@@ -59,6 +59,9 @@ docker buildx build \
   .
 ```
 
+Plain `docker build` commands continue to export the unpacked output layout.
+Select a `packages-*` target only when release-shaped archives are required.
+
 The `openvmm-deps` tarball no longer contains a kernel; consumers that
 need a Linux-direct boot kernel (e.g. petri's `Firmware::LinuxDirect`)
 should fetch the matching `openvmm-test-linux-<version>` artifact for

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Build release-shaped archives directly from the Docker graph:
 
 ```bash
 docker buildx build \
-  --platform linux/arm64 \
+  --platform aarch64 \
   --target packages-aarch64 \
   --build-arg VERSION=<version> \
   --output type=local,dest=out/package \

--- a/README.md
+++ b/README.md
@@ -48,6 +48,17 @@ The release pipeline packs each of these into its own tarball:
 | `openvmm-test-virtio-villain.<arch>.<ver>.tar.gz`     | virtio-villain guest initramfs + `tests.tsv` |
 | `qemu-linux-static.<arch>.<ver>.tar.gz`                | static QEMU system emulators (TCG)    |
 
+Build release-shaped archives directly from the Docker graph:
+
+```bash
+docker buildx build \
+  --platform linux/arm64 \
+  --target packages-aarch64 \
+  --build-arg VERSION=<version> \
+  --output type=local,dest=out/package \
+  .
+```
+
 The `openvmm-deps` tarball no longer contains a kernel; consumers that
 need a Linux-direct boot kernel (e.g. petri's `Firmware::LinuxDirect`)
 should fetch the matching `openvmm-test-linux-<version>` artifact for
@@ -77,7 +88,11 @@ binaries for multiple guest architectures) and runs separately from the
 main cross-compilation pipeline.
 
 ```bash
-docker build -f Dockerfile.virtio-win --output type=local,dest=out .
+docker buildx build \
+  -f Dockerfile.virtio-win \
+  --target packages \
+  --build-arg VERSION=<version> \
+  --output type=local,dest=out .
 ```
 
 The output preserves the ISO's directory layout (e.g.

--- a/README.md
+++ b/README.md
@@ -59,8 +59,9 @@ docker buildx build \
   .
 ```
 
-Plain `docker build` commands continue to export the unpacked output layout.
-Select a `packages-*` target only when release-shaped archives are required.
+The default final stage remains the unpacked `output` layout. Select a
+`packages-x86_64` or `packages-aarch64` target only when release-shaped
+archives are required.
 
 The `openvmm-deps` tarball no longer contains a kernel; consumers that
 need a Linux-direct boot kernel (e.g. petri's `Firmware::LinuxDirect`)
@@ -93,15 +94,23 @@ main cross-compilation pipeline.
 ```bash
 docker buildx build \
   -f Dockerfile.virtio-win \
+  --output type=local,dest=out .
+```
+
+This output preserves the ISO's directory layout (e.g.
+`NetKVM/2k22/amd64/`, `NetKVM/2k25/ARM64/`). To build the release-shaped
+archive instead:
+
+```bash
+docker buildx build \
+  -f Dockerfile.virtio-win \
   --target packages \
   --build-arg VERSION=<version> \
   --output type=local,dest=out .
 ```
 
-The output preserves the ISO's directory layout (e.g.
-`NetKVM/2k22/amd64/`, `NetKVM/2k25/ARM64/`). Currently only NetKVM
-drivers are extracted; to add more driver families, extend the `grep`
-filter in `Dockerfile.virtio-win`.
+Currently only NetKVM drivers are extracted; to add more driver families,
+extend the `grep` filter in `Dockerfile.virtio-win`.
 
 The ISO is mirrored to the
 [`virtio-iso-v1`](https://github.com/microsoft/openvmm-deps/releases/tag/virtio-iso-v1)


### PR DESCRIPTION
This lets you generate packages like CI would locally, to validate any new changes in openvmm. 